### PR TITLE
feat: auto-derive Phase 7 min-ctk from Phase 6 stop reason (OOM vs timeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ When `--min-*` flags are not set, Phase 7 auto-applies minimum filters so the co
 | NGL | `MAX_NGL − 1 step` (top 2 values) | `--min-ngl 0` |
 | Threads | `HW_CPU_PHYSICAL` (physical core count) | `--min-threads 1` |
 | Context | `--start-ctx` value, else `8192` | `--min-ctx 0` |
-| KV type | `q8_0` | `--min-ctk q4_0` |
+| KV type | `q8_0` normally; auto-lowered to most-compressed Phase-2-validated type when Phase 6 hit OOM | `--min-ctk q4_0` |
 | Batch | `BEST_B / 2` | `--min-b 512` |
 
 If `--start-ctx` is set and no context at or above that size succeeds in Phase 6, Phase 7 is skipped with a clear warning rather than silently running a useless matrix at a tiny fallback context.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -713,7 +713,7 @@ is logged at startup so the operator can see exactly what is active:
 | `ngl` | `max_ngl − 1 step` (top 2 ngl values) | `--min-ngl 0` |
 | `threads` | `HW_CPU_PHYSICAL` (physical core count) | `--min-threads 1` |
 | `ctx` | `--start-ctx` value if set, else `8192` | `--min-ctx 0` |
-| `ctk` | `q8_0` | `--min-ctk q4_0` |
+| `ctk` | `q8_0` when Phase 6 stopped cleanly or on timeout; auto-lowered to most-compressed Phase-2-validated type when Phase 6 hit OOM (turbo if available, else `q4_0`) | `--min-ctk q8_0` to force default |
 | `b` | `BEST_B / 2` | `--min-b 512` |
 
 These auto-defaults do not affect phases 1–6 — those still run full discovery.

--- a/llamaseye.sh
+++ b/llamaseye.sh
@@ -2425,12 +2425,37 @@ phase7_combination_matrix() {
     ctx_p7="$(apply_phase7_mins "ctx"     "$(echo "${WS_CTX}" | tr ' ' '\n')"     "${eff_min_ctx}")"
     nkvo_p7="$(echo "${WS_NKVO}" | tr ' ' '\n' | grep -v '^$' || true)"
 
-    # KV type: default to q8_0 (int8) minimum — exclude heavily-compressed types
-    # unless the user explicitly asks for them or lowers the bar.
+    # KV type minimum: auto-derive from Phase 6 stop reason when not explicitly set.
+    # - Phase 6 hit OOM  → turbo compression may unlock larger contexts → open to lowest
+    #                       validated ctk type (could be turbo2 if TurboQuant available)
+    # - Phase 6 timed out or reached 131072 cleanly → throughput-limited, not VRAM-limited
+    #                       → turbo won't help, keep q8_0 default
     local eff_min_ctk="${OPT_MIN_CTK}"
     if [[ -z "${eff_min_ctk}" ]]; then
-        eff_min_ctk="q8_0"
-        log "[Phase 7] Auto min-ctk=${eff_min_ctk} (default minimum quality; override with --min-ctk TYPE or SWEEP_MIN_CTK=TYPE)"
+        local _p6_oom_count
+        _p6_oom_count="$(jq -s '[.[] | select(.phase==6 and .status=="oom")] | length' \
+            "${OUTPUT_MODEL_DIR}/sweep.jsonl" 2>/dev/null || echo 0)"
+        if [[ "${_p6_oom_count}" -gt 0 ]]; then
+            # OOM ceiling: find the most-compressed ctk type Phase 2 validated
+            local _auto_ctk
+            _auto_ctk="$(jq -rs '
+                def rank: {"turbo2":0,"turbo3":1,"turbo4":2,"q4_0":3,"q8_0":4,"f16":5}[.] // 99;
+                [.[] | select(.phase==2 and .status=="ok") | .params.ctk] |
+                unique | sort_by(rank) | .[0] // "q4_0"
+            ' "${OUTPUT_MODEL_DIR}/sweep.jsonl" 2>/dev/null || echo "q4_0")"
+            eff_min_ctk="${_auto_ctk}"
+            log "[Phase 7] Auto min-ctk=${eff_min_ctk} (Phase 6 hit OOM — turbo may unlock larger contexts; override with --min-ctk)"
+        else
+            local _p6_timeout_count
+            _p6_timeout_count="$(jq -s '[.[] | select(.phase==6 and .status=="timeout")] | length' \
+                "${OUTPUT_MODEL_DIR}/sweep.jsonl" 2>/dev/null || echo 0)"
+            eff_min_ctk="q8_0"
+            if [[ "${_p6_timeout_count}" -gt 0 ]]; then
+                log "[Phase 7] Auto min-ctk=${eff_min_ctk} (Phase 6 stopped on timeout — turbo won't unlock more context; override with --min-ctk)"
+            else
+                log "[Phase 7] Auto min-ctk=${eff_min_ctk} (Phase 6 reached max context cleanly; override with --min-ctk TYPE or SWEEP_MIN_CTK=TYPE)"
+            fi
+        fi
     fi
 
     local ctk_values

--- a/skills/llamaseye/SKILL.md
+++ b/skills/llamaseye/SKILL.md
@@ -341,7 +341,7 @@ ssh user@inference-host "chmod +x ~/llamaseye.sh"
 | 4 | KV offload (nkvo) | KV cache in VRAM vs RAM | If nkvo behaviour already known |
 | 5 | Batch/ubatch | Batch and micro-batch size combos | If throughput tuning not needed |
 | 6 | Context size | Prompt size 128 → 131072 (stops at OOM or timeout) | If context ceiling already known |
-| 7 | Combo matrix | Cartesian product of all values tested in phases 1–6 | Early exploration; run eventually |
+| 7 | Combo matrix | Cartesian product of all values tested in phases 1–6; auto min-ctk lowered to include turbo types when Phase 6 hit OOM | Early exploration; run eventually |
 
 ---
 


### PR DESCRIPTION
## Summary

When `--min-ctk` is not explicitly set, Phase 7 now inspects `sweep.jsonl` to determine why Phase 6 stopped and derives the appropriate `min-ctk` automatically:

| Phase 6 stop reason | Auto min-ctk | Rationale |
|---|---|---|
| Hit OOM | most-compressed Phase-2-validated type (turbo2/3/4 or q4_0) | Turbo compression may unlock larger contexts |
| Stopped on timeout | `q8_0` | Throughput-limited — turbo adds overhead without enabling new ctx sizes |
| Reached 131072 cleanly | `q8_0` | No ceiling to push past |

The OOM path picks the most-compressed ctk that Phase 2 actually validated (queries `sweep.jsonl`), so it naturally handles the case where TurboQuant wasn't available (falls back to `q4_0`).

User can always override with `--min-ctk` / `SWEEP_MIN_CTK`.

Note: the Phase 7 estimate count bug (secondary fix listed in #7) was already resolved in #9.

Closes #7

## Test plan

- [ ] Sweep a VRAM-constrained model that OOMs in Phase 6 — confirm Phase 7 log shows `Auto min-ctk=turbo2` (or lowest validated type) and turbo combos run
- [ ] Sweep a CPU-bound model that times out in Phase 6 — confirm `Auto min-ctk=q8_0 (Phase 6 stopped on timeout)`
- [ ] Sweep a model that reaches 131072 — confirm `Auto min-ctk=q8_0 (Phase 6 reached max context cleanly)`
- [ ] Pass `--min-ctk f16` explicitly — confirm auto-derivation is skipped entirely
- [ ] `bash -n llamaseye.sh` — syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)