### PR TITLE
feat: auto-load .env file; add --env-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,21 @@ nohup ./llamaseye --models-dir ~/Models --output-dir ./results > /dev/null 2>&1 
 
 ### Using a .env file
 
-All environment variables can be set in a `.env` file instead of passing flags every time:
+All environment variables can be set in a `.env` file instead of passing flags every time. The binary **auto-loads `.env` from the working directory** if it exists — no `source` step needed:
 
 ```sh
 cp example.env .env
 # Edit .env to match your paths and preferences
-source .env && ./llamaseye --models-dir ~/Models
+./llamaseye --models-dir ~/Models   # .env is loaded automatically
 ```
+
+To load a file at a different path use `--env-file`:
+
+```sh
+./llamaseye --env-file ~/my-config.env --model ~/Models/model.gguf
+```
+
+**Load order:** `.env` file → process environment → CLI flags. Process env vars always override file values; CLI flags override everything.
 
 Every CLI flag has a corresponding environment variable — env vars set the default value, and CLI flags override them when both are provided. `example.env` in the repo root documents every available variable with its default value and a description. The most important ones to set are `LLAMA_BENCH_BIN` (path to your llama-bench binary) and `SWEEP_OUTPUT_DIR` (where results are written).
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,10 @@ func Parse(args []string) (*config.Config, []string, error) {
 	fs.BoolVar(&cfg.OptimizedSweep, "optimized-sweep", cfg.OptimizedSweep,
 		"Parse GGUF metadata to derive start flags automatically")
 
+	// --env-file is pre-consumed in main.go before Parse is called.
+	// Register it here so it appears in --help output.
+	fs.String("env-file", "", `Load environment variables from FILE before flag parsing (default: auto-load ".env" if present)`)
+
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "llamaseye v0.1.0 — exhaustive llama-bench parameter sweep harness\n\n")
 		fmt.Fprintf(os.Stderr, "Usage: llamaseye [options]\n\n")

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1064,10 +1064,13 @@ llamaseye is a self-contained Go binary (previously a Bash script: `llamaseye.sh
 
 ### Configuration variables
 
-All overridable via environment variable or CLI flag. The script reads
-environment variables first, then CLI flags override them, so both styles work.
+All overridable via `.env` file, environment variable, or CLI flag. Load order (lowest → highest priority):
 
-> **Note:** Every CLI flag has a corresponding environment variable. CLI flags always take precedence over environment variables when both are set.
+1. `.env` file (auto-loaded from the working directory; override with `--env-file <path>`)
+2. Process environment variables
+3. CLI flags
+
+> **Note:** Every CLI flag has a corresponding `SWEEP_*` environment variable. CLI flags always take precedence. Process env vars always win over `.env` file values.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/envfile/envfile.go
+++ b/envfile/envfile.go
@@ -1,0 +1,62 @@
+// Package envfile loads KEY=VALUE pairs from a .env file into the process environment.
+// Existing env vars are NOT overwritten — process environment always wins over the file.
+package envfile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Load reads path and sets any KEY=VALUE pairs as environment variables,
+// skipping keys that are already set in the process environment.
+// Blank lines and lines beginning with # are ignored.
+// Returns an error only if the file exists but cannot be read or parsed.
+func Load(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Strip inline comments: KEY=VALUE # comment
+		if idx := strings.Index(line, " #"); idx != -1 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		idx := strings.IndexByte(line, '=')
+		if idx < 1 {
+			return fmt.Errorf("%s:%d: expected KEY=VALUE, got %q", path, lineNum, line)
+		}
+		key := strings.TrimSpace(line[:idx])
+		val := strings.TrimSpace(line[idx+1:])
+		// Strip optional surrounding quotes
+		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') ||
+			(val[0] == '\'' && val[len(val)-1] == '\'')) {
+			val = val[1 : len(val)-1]
+		}
+		// Process env wins: only set if not already present
+		if _, exists := os.LookupEnv(key); !exists {
+			if err := os.Setenv(key, val); err != nil {
+				return fmt.Errorf("%s:%d: setenv %s: %w", path, lineNum, key, err)
+			}
+		}
+	}
+	return scanner.Err()
+}
+
+// LoadIfExists loads path if it exists, silently returns nil if it does not.
+func LoadIfExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	return Load(path)
+}

--- a/envfile/envfile_test.go
+++ b/envfile/envfile_test.go
@@ -1,0 +1,121 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeEnv(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func TestLoad_Basic(t *testing.T) {
+	path := writeEnv(t, "LLAMASEYE_TEST_KEY=hello\nLLAMASEYE_TEST_NUM=42\n")
+	t.Cleanup(func() {
+		os.Unsetenv("LLAMASEYE_TEST_KEY")
+		os.Unsetenv("LLAMASEYE_TEST_NUM")
+	})
+
+	if err := Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v := os.Getenv("LLAMASEYE_TEST_KEY"); v != "hello" {
+		t.Errorf("KEY = %q, want hello", v)
+	}
+	if v := os.Getenv("LLAMASEYE_TEST_NUM"); v != "42" {
+		t.Errorf("NUM = %q, want 42", v)
+	}
+}
+
+func TestLoad_ProcessEnvWins(t *testing.T) {
+	// Pre-set the var — file value must NOT override it
+	os.Setenv("LLAMASEYE_PRESET", "process_value")
+	t.Cleanup(func() { os.Unsetenv("LLAMASEYE_PRESET") })
+
+	path := writeEnv(t, "LLAMASEYE_PRESET=file_value\n")
+	if err := Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v := os.Getenv("LLAMASEYE_PRESET"); v != "process_value" {
+		t.Errorf("env = %q, want process_value (process env should win)", v)
+	}
+}
+
+func TestLoad_SkipsCommentsAndBlanks(t *testing.T) {
+	path := writeEnv(t, `
+# This is a comment
+LLAMASEYE_REAL=yes
+
+# Another comment
+`)
+	t.Cleanup(func() { os.Unsetenv("LLAMASEYE_REAL") })
+
+	if err := Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v := os.Getenv("LLAMASEYE_REAL"); v != "yes" {
+		t.Errorf("REAL = %q, want yes", v)
+	}
+}
+
+func TestLoad_InlineComment(t *testing.T) {
+	path := writeEnv(t, "LLAMASEYE_IC=value # inline comment\n")
+	t.Cleanup(func() { os.Unsetenv("LLAMASEYE_IC") })
+
+	if err := Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v := os.Getenv("LLAMASEYE_IC"); v != "value" {
+		t.Errorf("IC = %q, want value (inline comment stripped)", v)
+	}
+}
+
+func TestLoad_QuotedValues(t *testing.T) {
+	path := writeEnv(t, `LLAMASEYE_DQ="double quoted"` + "\n" + `LLAMASEYE_SQ='single quoted'` + "\n")
+	t.Cleanup(func() {
+		os.Unsetenv("LLAMASEYE_DQ")
+		os.Unsetenv("LLAMASEYE_SQ")
+	})
+
+	if err := Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v := os.Getenv("LLAMASEYE_DQ"); v != "double quoted" {
+		t.Errorf("DQ = %q, want 'double quoted'", v)
+	}
+	if v := os.Getenv("LLAMASEYE_SQ"); v != "single quoted" {
+		t.Errorf("SQ = %q, want 'single quoted'", v)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	err := Load("/nonexistent/path/.env")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoadIfExists_Missing(t *testing.T) {
+	// Should not error for missing file
+	if err := LoadIfExists("/nonexistent/.env"); err != nil {
+		t.Errorf("LoadIfExists missing: %v", err)
+	}
+}
+
+func TestLoadIfExists_Present(t *testing.T) {
+	path := writeEnv(t, "LLAMASEYE_LIE=exists\n")
+	t.Cleanup(func() { os.Unsetenv("LLAMASEYE_LIE") })
+
+	if err := LoadIfExists(path); err != nil {
+		t.Fatalf("LoadIfExists: %v", err)
+	}
+	if v := os.Getenv("LLAMASEYE_LIE"); v != "exists" {
+		t.Errorf("LIE = %q, want exists", v)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/justinphilpott/llamaseye/bench"
 	"github.com/justinphilpott/llamaseye/cmd"
+	"github.com/justinphilpott/llamaseye/envfile"
 	"github.com/justinphilpott/llamaseye/hardware"
 	"github.com/justinphilpott/llamaseye/output"
 	"github.com/justinphilpott/llamaseye/sweep"
@@ -22,6 +23,20 @@ func main() {
 }
 
 func run(args []string) error {
+	// Load .env before parsing flags so SWEEP_* vars are visible to config.Defaults().
+	// --env-file is pre-scanned from args; full flag parsing happens in cmd.Parse below.
+	envPath, args := extractEnvFileFlag(args)
+	if envPath != "" {
+		if err := envfile.Load(envPath); err != nil {
+			return fmt.Errorf("--env-file %s: %w", envPath, err)
+		}
+	} else {
+		// Auto-load .env from working directory if present
+		if err := envfile.LoadIfExists(".env"); err != nil {
+			return fmt.Errorf(".env: %w", err)
+		}
+	}
+
 	cfg, models, err := cmd.Parse(args)
 	if err != nil {
 		return err
@@ -120,6 +135,27 @@ func run(args []string) error {
 
 	logger.Log("All sweeps complete.")
 	return nil
+}
+
+// extractEnvFileFlag scans args for --env-file <path> or --env-file=<path>,
+// removes those tokens from the slice, and returns the path and remaining args.
+func extractEnvFileFlag(args []string) (path string, remaining []string) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--env-file" && i+1 < len(args) {
+			path = args[i+1]
+			remaining = append(remaining, args[:i]...)
+			remaining = append(remaining, args[i+2:]...)
+			return
+		}
+		if strings.HasPrefix(arg, "--env-file=") {
+			path = strings.TrimPrefix(arg, "--env-file=")
+			remaining = append(remaining, args[:i]...)
+			remaining = append(remaining, args[i+1:]...)
+			return
+		}
+	}
+	return "", args
 }
 
 func stemOf(path string) string {

--- a/skills/llamaseye/SKILL.md
+++ b/skills/llamaseye/SKILL.md
@@ -43,42 +43,42 @@ description: >
 
 ## Running a Sweep
 
-The binary reads `SWEEP_*` env vars from the environment. Source `.env` before running if it exists:
+The binary **auto-loads `.env` from the working directory** — no `source` step needed.
+Run from `~/Src/llamaseye/` and it picks up `.env` automatically:
 
 ```sh
-# Standard invocation pattern — always use this form when running remotely:
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; ./llamaseye <flags>
+# Standard invocation — .env is loaded automatically
+cd ~/Src/llamaseye && ./llamaseye <flags>
 ```
-
-If `.env` does not exist yet, the binary will use built-in defaults — but
-paths like `LLAMA_BENCH_BIN` and `SWEEP_OUTPUT_DIR` may need to be passed as flags.
 
 ```sh
 # Single model -- full sweep
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; ./llamaseye --model ~/Models/Qwen3-14B-Q4_K_M.gguf --output-dir ~/Models/bench/sweep
+cd ~/Src/llamaseye && ./llamaseye --model ~/Models/Qwen3-14B-Q4_K_M.gguf --output-dir ~/Models/bench/sweep
 
 # All models in a directory
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; ./llamaseye --models-dir ~/Models --output-dir ~/Models/bench/sweep
+cd ~/Src/llamaseye && ./llamaseye --models-dir ~/Models --output-dir ~/Models/bench/sweep
 
 # Filtered list of models
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; ./llamaseye --models-dir ~/Models --model-list ~/bench_list.txt --output-dir ~/Models/bench/sweep
+cd ~/Src/llamaseye && ./llamaseye --models-dir ~/Models --model-list ~/bench_list.txt --output-dir ~/Models/bench/sweep
 
 # With TurboQuant binary (enables turbo2/turbo3/turbo4 KV types)
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; ./llamaseye --model ~/Models/model.gguf \
+cd ~/Src/llamaseye && ./llamaseye --model ~/Models/model.gguf \
   --llama-bench ~/llama.cpp/build/bin/llama-bench \
   --turbo-bench ~/llama-cpp-turboquant/build/bin/llama-bench
 
 # Resume an interrupted sweep
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; ./llamaseye --model ~/Models/model.gguf --resume
+cd ~/Src/llamaseye && ./llamaseye --model ~/Models/model.gguf --resume
 
 # Run only specific phases
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; ./llamaseye --model ~/Models/model.gguf --only-phases 6,7
+cd ~/Src/llamaseye && ./llamaseye --model ~/Models/model.gguf --only-phases 6,7
 
 # Unattended overnight
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env
+cd ~/Src/llamaseye
 nohup ./llamaseye --models-dir ~/Models > /dev/null 2>&1 &
 tail -f ~/Models/bench/sweep/sweep.log
 ```
+
+To load a config from a non-default path: `./llamaseye --env-file ~/custom.env <flags>`
 
 ---
 
@@ -193,9 +193,9 @@ documenting every variable.
 ```sh
 # One-time setup on the inference host
 cd ~/Src/llamaseye && cp example.env .env
-# Edit .env to set your paths — it lives alongside the script at ~/Src/llamaseye/.env
-# Source before running (the standard invocation pattern already does this):
-cd ~/Src/llamaseye && [[ -f .env ]] && source .env; bash ~/Src/llamaseye/llamaseye.sh --models-dir ~/Models --output-dir ~/Models/bench/sweep
+# Edit .env to set your paths — it lives alongside the binary at ~/Src/llamaseye/.env
+# The binary auto-loads it; just run from ~/Src/llamaseye/:
+cd ~/Src/llamaseye && ./llamaseye --models-dir ~/Models --output-dir ~/Models/bench/sweep
 ```
 
 `.env` is gitignored — local paths are never committed.


### PR DESCRIPTION
## Summary

- Binary now auto-loads `.env` from the working directory at startup — no more `source .env` before running
- `--env-file <path>` flag for an explicit path (missing file = error)
- Load order: `.env` file → process environment → CLI flags (process env always wins over the file)

## Details

New `envfile` package handles parsing:
- Blank lines and `#` comments skipped
- Inline comments stripped (`KEY=value # comment` → `value`)
- Single and double quoted values unquoted
- Existing process env vars are never overwritten

## Test plan

- [ ] `go test ./envfile/... -cover` — 92.6% coverage
- [ ] `go test -race ./...` — all pass
- [ ] Running `./llamaseye --help` shows `--env-file` in flag list
- [ ] Running from `~/Src/llamaseye/` on remote picks up `.env` automatically without `source`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)