### PR TITLE
fix: remove machine-specific default paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release --target llama-bench -j$(nproc)
 ```
 
-The binary will be at `build/bin/llama-bench`. Pass its path to llamaseye via `--llama-bench <path>` or set the `LLAMA_BENCH_BIN` environment variable. The default assumed path is `~/llama.cpp/build/bin/llama-bench`.
+The binary will be at `build/bin/llama-bench`. Pass its path to llamaseye via `--llama-bench <path>` or set the `LLAMA_BENCH_BIN` environment variable. There is no default — llamaseye will exit with an error if the binary is not specified.
 
 > The build flags you choose determine which backends and features are available during the sweep. llamaseye works with any valid llama-bench binary — it does not require any specific build flags itself.
 
@@ -152,7 +152,7 @@ If these are absent, llamaseye disables the corresponding thermal guard and logs
 | `--model <path>` | Single GGUF model to benchmark |
 | `--models-dir <dir>` | Directory to scan for GGUF models |
 | `--model-list <file>` | Text file listing model filenames (one per line) |
-| `--output-dir <dir>` | Root directory for all results (default: `~/Models/bench/sweep`) |
+| `--output-dir <dir>` | Root directory for all results (default: `./results`) |
 | `--llama-bench <path>` | Path to standard llama-bench binary |
 | `--turbo-bench <path>` | Path to TurboQuant llama-bench binary (enables turbo2/3/4 KV types) |
 | `--ngl-step <n>` | Step size for NGL axis sweep (default: 4) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1074,10 +1074,10 @@ All overridable via `.env` file, environment variable, or CLI flag. Load order (
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LLAMA_BENCH_BIN` | `~/llama.cpp/build/bin/llama-bench` | Path to standard llama-bench binary |
+| `LLAMA_BENCH_BIN` | *(required — no default)* | Path to standard llama-bench binary |
 | `SWEEP_TURBO_BENCH_BIN` | *(unset)* | Path to TurboQuant llama-bench binary (optional) |
 | `SWEEP_MODELS_DIR` | *(required if no model flag)* | Directory to scan for `.gguf` files |
-| `SWEEP_OUTPUT_DIR` | `~/Models/bench/sweep` | Root output directory |
+| `SWEEP_OUTPUT_DIR` | `./results` | Root output directory |
 | `SWEEP_NGL_STEP` | `4` | Layer step for ngl sweep |
 | `SWEEP_REPETITIONS` | `3` | `-r` for main runs |
 | `SWEEP_PROBE_REPS` | `1` | `-r` for Phase 0 probe |
@@ -1271,7 +1271,7 @@ Model selection (one required):
                              Use with --models-dir to resolve bare filenames.
 
 Output:
-  --output-dir <path>        Root output directory. Default: ~/Models/bench/sweep
+  --output-dir <path>        Root output directory. Default: ./results
                              Each model gets its own subdirectory inside.
 
 Sweep control:
@@ -1286,7 +1286,7 @@ Sweep control:
 
 Hardware / environment:
   --llama-bench <path>       Path to standard llama-bench binary.
-                             Default: ~/llama.cpp/build/bin/llama-bench
+                             Required — no default.
   --turbo-bench <path>       Path to TurboQuant llama-bench binary (optional).
                              Enables turbo2/turbo3/turbo4 KV cache types in
                              Phase 2 and Phase 7. Must be built from:

--- a/example.env
+++ b/example.env
@@ -16,7 +16,8 @@
 # Path to your llama-bench binary (built from llama.cpp).
 # Must be compiled with the right backend flags for your hardware.
 # See README.md > Dependencies for build instructions.
-LLAMA_BENCH_BIN="${HOME}/llama.cpp/build/bin/llama-bench"
+# Required — no default. Example:
+# LLAMA_BENCH_BIN="${HOME}/llama.cpp/build/bin/llama-bench"
 
 # Path to a TurboQuant llama-bench binary (optional).
 # Enables turbo2/turbo3/turbo4 KV cache types.
@@ -29,11 +30,13 @@ LLAMA_BENCH_BIN="${HOME}/llama.cpp/build/bin/llama-bench"
 # -----------------------------------------------------------------------------
 
 # Directory to scan for .gguf model files when no --model flag is given.
+# No default — set this to wherever your .gguf files live. Example:
 # SWEEP_MODELS_DIR="${HOME}/Models"
 
 # Root directory where sweep results are written.
 # Each model gets its own subdirectory: <SWEEP_OUTPUT_DIR>/<model-stem>/
-SWEEP_OUTPUT_DIR="${HOME}/Models/bench/sweep"
+# Defaults to ./results (relative to wherever you run the script).
+# SWEEP_OUTPUT_DIR="./results"
 
 # -----------------------------------------------------------------------------
 # Sweep behaviour

--- a/llamaseye.sh
+++ b/llamaseye.sh
@@ -27,8 +27,8 @@ set -euo pipefail
 # CONFIGURATION VARIABLES — override via environment or CLI flags
 # =============================================================================
 
-# Path to the llama-bench binary
-LLAMA_BENCH_BIN="${LLAMA_BENCH_BIN:-${HOME}/llama.cpp/build/bin/llama-bench}"
+# Path to the llama-bench binary (required — must be set via LLAMA_BENCH_BIN env var or --llama-bench flag)
+LLAMA_BENCH_BIN="${LLAMA_BENCH_BIN:-}"
 
 # Optional turbo-bench binary (supports turbo3 KV type)
 SWEEP_TURBO_BENCH_BIN="${SWEEP_TURBO_BENCH_BIN:-}"
@@ -37,7 +37,7 @@ SWEEP_TURBO_BENCH_BIN="${SWEEP_TURBO_BENCH_BIN:-}"
 SWEEP_MODELS_DIR="${SWEEP_MODELS_DIR:-}"
 
 # Root directory where all sweep output is written
-SWEEP_OUTPUT_DIR="${SWEEP_OUTPUT_DIR:-${HOME}/Models/bench/sweep}"
+SWEEP_OUTPUT_DIR="${SWEEP_OUTPUT_DIR:-./results}"
 
 # NGL granularity for phase1 sweep (layers per step)
 SWEEP_NGL_STEP="${SWEEP_NGL_STEP:-4}"
@@ -3121,6 +3121,7 @@ main() {
     print_hardware_summary
 
     # Validate binary exists
+    [[ -n "${LLAMA_BENCH_BIN}" ]] || die "llama-bench binary not specified. Set LLAMA_BENCH_BIN in .env or pass --llama-bench <path>"
     [[ -x "${LLAMA_BENCH_BIN}" ]] || die "llama-bench not found or not executable: ${LLAMA_BENCH_BIN}"
 
     # Pre-sweep confirmation (skipped with --no-confirm or --dry-run)

--- a/skills/llamaseye/SKILL.md
+++ b/skills/llamaseye/SKILL.md
@@ -206,10 +206,10 @@ cd ~/Src/llamaseye && ./llamaseye --models-dir ~/Models --output-dir ~/Models/be
 
 | Variable | What it controls | Example |
 |----------|-----------------|----------|
-| `LLAMA_BENCH_BIN` | Path to the standard llama-bench binary | `~/llama.cpp/build/bin/llama-bench` |
+| `LLAMA_BENCH_BIN` | Path to the standard llama-bench binary (**required — no default**) | `~/llama.cpp/build/bin/llama-bench` |
 | `SWEEP_TURBO_BENCH_BIN` | Path to TurboQuant binary (optional) | `~/llama-cpp-turboquant/build/bin/llama-bench` |
 | `SWEEP_MODELS_DIR` | Directory scanned for .gguf files | `~/Models` |
-| `SWEEP_OUTPUT_DIR` | Root directory for all sweep results | `~/Models/bench/sweep` |
+| `SWEEP_OUTPUT_DIR` | Root directory for all sweep results (default: `./results`) | `~/Models/bench/sweep` |
 | `SWEEP_NGL_STEP` | Layer step size for NGL sweep | `4` (use `2` near VRAM edge) |
 | `SWEEP_REPETITIONS` | Benchmark reps per run (`-r`) | `3` |
 | `SWEEP_TIMEOUT_SEC` | Per-run kill timeout (seconds) | `600` |
@@ -318,8 +318,7 @@ cmake --build build --config Release --target llama-bench <JOBS>
 ./build/bin/llama-bench --help 2>&1 | head -5
 ```
 
-The binary path defaults to `~/llama.cpp/build/bin/llama-bench`. Override with
-`--llama-bench <path>` or the `LLAMA_BENCH_BIN` environment variable.
+There is no default binary path — `LLAMA_BENCH_BIN` must be set or `--llama-bench` must be passed. The script exits with a clear error if neither is provided.
 
 ### Step 3 — Build TurboQuant llama-bench (optional)
 


### PR DESCRIPTION
## Summary

Closes #22

- **`LLAMA_BENCH_BIN`**: no longer has a default (`~/llama.cpp/build/bin/llama-bench` was hardcoded to the original developer's machine). The script now fails immediately with a clear message if neither `LLAMA_BENCH_BIN` nor `--llama-bench` is set.
- **`SWEEP_OUTPUT_DIR`**: default changed from `~/Models/bench/sweep` to `./results` (relative to CWD, matching what the README examples already showed).
- **`example.env`**: `LLAMA_BENCH_BIN` is now commented out with a note it's required; `SWEEP_OUTPUT_DIR` is commented out showing `./results`; `SWEEP_MODELS_DIR` comment clarifies there's no default.

## Test plan

- [ ] Run `./llamaseye.sh --model /path/to/model.gguf` without setting `LLAMA_BENCH_BIN` — should exit with `"llama-bench binary not specified. Set LLAMA_BENCH_BIN in .env or pass --llama-bench <path>"`
- [ ] Run with `--llama-bench /path/to/llama-bench` but no `--output-dir` — results should land in `./results/<model-stem>/`
- [ ] Verify `example.env` has no uncommented paths pointing at `~/llama.cpp` or `~/Models`

🤖 Generated with [Claude Code](https://claude.com/claude-code)