### PR TITLE
feat: focused phase re-run — skip already-tested combos via --focused (closes #33)

### DIFF
--- a/.claude/skills/llamaseye/SKILL.md
+++ b/.claude/skills/llamaseye/SKILL.md
@@ -98,6 +98,7 @@ To load a config from a non-default path: `./llamaseye --env-file ~/custom.env <
 | Diagnose OOM / unexpected behavior | `--debug` |
 | Get more diverse goal configs (not just tuning variants) | `--goal "..." --goal-hits 5` |
 | Re-run one or more phases | `--only-phases 6,7` |
+| Re-run a phase but only test new combos | `--only-phases 2 --focused` |
 | Skip Phase 7 | `--skip-phases 7` |
 | All models in a dir | `--models-dir <dir>` |
 | Curated model subset | `--model-list ~/list.txt` |
@@ -244,6 +245,7 @@ cd ~/Src/llamaseye && ./llamaseye --models-dir ~/Models --output-dir ~/Models/be
 | `SWEEP_CTV_DIR` | `--ctv-dir` | `up` | V-cache quant sweep direction |
 | `SWEEP_SKIP_PHASES` | `--skip-phases` | *(unset)* | Skip these phases, comma-separated |
 | `SWEEP_ONLY_PHASES` | `--only-phases` | *(unset)* | Run only these phases, comma-separated |
+| `SWEEP_FOCUSED` | `--focused` | `false` | Only run combos not already in sweep.jsonl (requires `--only-phases`) |
 | `SWEEP_RESUME` | `--resume` | `false` | Skip already-completed phases |
 | `SWEEP_NO_CONFIRM` | `--no-confirm` | `false` | Skip pre-sweep confirmation |
 | `SWEEP_ASYMMETRIC_KV` | `--asymmetric-kv` | `true` | Include asymmetric K/V combos in Phase 2 (requires turbo binary) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.7.0] — 2026-04-09
+
+### Added
+- **Focused phase re-run** (`--focused`) — when combined with `--only-phases`, each phase diffs its planned combos against existing `status: "ok"` entries in `sweep.jsonl` and only runs combos not yet present. Skipped combos still populate working sets so downstream phases see the full picture. Env var: `SWEEP_FOCUSED` (default: `false`). Closes #33.
+
+---
+
 ## [1.6.0] — 2026-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.7.1] — 2026-04-09
+
+### Fixed
+- Deduplicated combo key logic between `output.ComboKey` and the removed `phase.FocusedComboKey` to prevent drift.
+- Used `errors.Is(err, os.ErrNotExist)` instead of `os.IsNotExist` for robust missing-file detection in `--focused` mode.
+- Phase 7 now logs skipped combo counts separately from executed run counts when `--focused` is active.
+
+---
+
 ## [1.7.0] — 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ If these are absent, llamaseye disables the corresponding thermal guard and logs
 | `--resume` | Resume a previous sweep, skipping completed phases |
 | `--overwrite` | Delete existing output dir and re-run everything |
 | `--only-phases <list>` | Comma-separated list of phase numbers to run (e.g. `0,1,7`) |
+| `--focused` | Only run combos not already in `sweep.jsonl` (requires `--only-phases`). Skipped combos still populate working sets for downstream phases. |
 | `--skip-phases <list>` | Comma-separated list of phase numbers to skip |
 | `--report` | Read-only: regenerate `sweep.md` from existing `sweep.jsonl` files without running any benchmarks. Also generates `summary.md` when multiple models are found. Combine with `--model`/`--models-dir` to target a subset; omit both to scan all subdirs of `--output-dir`. |
 | `--dry-run` | Print what would run without executing |
@@ -242,6 +243,7 @@ Every CLI flag can also be set via environment variable — useful for `.env` fi
 | `SWEEP_OVERWRITE` | `--overwrite` | `SWEEP_OVERWRITE=true` |
 | `SWEEP_SKIP_PHASES` | `--skip-phases` | `SWEEP_SKIP_PHASES=7` |
 | `SWEEP_ONLY_PHASES` | `--only-phases` | `SWEEP_ONLY_PHASES=0,1,6` |
+| `SWEEP_FOCUSED` | `--focused` | `SWEEP_FOCUSED=true` |
 | `SWEEP_NGL_STEP` | `--ngl-step` | `SWEEP_NGL_STEP=2` |
 | `SWEEP_START_NGL` | `--start-ngl` | `SWEEP_START_NGL=40` |
 | `SWEEP_NGL_DIR` | `--ngl-dir` | `SWEEP_NGL_DIR=down` |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func Parse(args []string, version string) (*config.Config, []string, error) {
 	fs.BoolVar(&cfg.DryRun, "dry-run", cfg.DryRun, "Print bench commands without executing")
 	fs.BoolVar(&cfg.NoConfirm, "no-confirm", cfg.NoConfirm, "Skip pre-sweep confirmation")
 	fs.BoolVar(&cfg.Report, "report", cfg.Report, "Regenerate sweep.md from existing .jsonl")
+	fs.BoolVar(&cfg.Focused, "focused", cfg.Focused, "Only run combos not already in sweep.jsonl (requires --only-phases)")
 
 	var onlyPhases, skipPhases string
 	fs.StringVar(&onlyPhases, "only-phases", "", "Run only these phases (comma-separated)")

--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,9 @@ type Config struct {
 	// Asymmetric K/V quant combos in Phase 2
 	AsymmetricKV bool
 
+	// Focused mode: only run combos not already in sweep.jsonl
+	Focused bool
+
 	// Debug mode
 	Debug bool
 }
@@ -183,6 +186,7 @@ func Defaults() *Config {
 		OptimizedSweep:  envBool("SWEEP_OPTIMIZED_SWEEP", false),
 		CTV:             envStr("SWEEP_CTV", ""),
 		AsymmetricKV:   envBool("SWEEP_ASYMMETRIC_KV", true),
+		Focused:         envBool("SWEEP_FOCUSED", false),
 		Debug:           envBool("SWEEP_DEBUG", false),
 	}
 }
@@ -216,6 +220,9 @@ func PhaseInList(phase int, list []int) bool {
 func (c *Config) Validate() error {
 	if c.Resume && c.Overwrite {
 		return fmt.Errorf("--resume and --overwrite are mutually exclusive")
+	}
+	if c.Focused && len(c.OnlyPhases) == 0 {
+		return fmt.Errorf("--focused requires --only-phases")
 	}
 	if len(c.OnlyPhases) > 0 && len(c.SkipPhases) > 0 {
 		return fmt.Errorf("--only-phases and --skip-phases are mutually exclusive")

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1169,6 +1169,7 @@ These variables were previously CLI-only but are now also read from the environm
 | `SWEEP_GOAL_HITS` | `3` | Distinct (ngl,ctk,nkvo,ctx) configs before goal early-exit (`--goal-hits`) |
 | `SWEEP_GOAL_SORT` | `tg` | Goal Results table sort axis: tg, ctx, ngl, pp (`--goal-sort`) |
 | `SWEEP_ONLY_PHASES` | *(unset)* | Run only these phases, comma-separated (`--only-phases`) |
+| `SWEEP_FOCUSED` | `false` | Only run combos not already in `sweep.jsonl` (`--focused`); requires `--only-phases` |
 | `SWEEP_SKIP_PHASES` | *(unset)* | Skip these phases, comma-separated (`--skip-phases`) |
 | `SWEEP_MODEL_LIST` | *(unset)* | Path to model list file (`--model-list`) |
 | `SWEEP_START_NGL` | *(unset)* | Begin NGL sweep at this value (`--start-ngl`) |
@@ -1351,6 +1352,7 @@ Sweep control:
   --repetitions <n>          Repetitions per run (-r). Default: 3.
   --only-phases <n,n,...>    Run only the listed phase numbers.
   --skip-phases <n,n,...>    Skip the listed phase numbers.
+  --focused                  Only run combos not already in sweep.jsonl (requires --only-phases).
   --resume                   Skip phases already marked complete in state.json.
   --overwrite                Delete existing output for a model and start fresh.
   --min-viable-ts <f>        Minimum TG t/s to mark viable. Default: 2.0.
@@ -1475,6 +1477,25 @@ load `phases_complete` and skip those phases. If `--overwrite` is set, delete
 the model's output directory and start clean. Default behavior (no flag) is
 to append and re-run all phases — useful if you want to collect more data
 without discarding what's already there.
+
+### Focused re-run (`--focused`)
+
+When `--focused` is combined with `--only-phases`, each phase diffs its planned
+combos against existing `status: "ok"` entries in `sweep.jsonl`. Only combos
+not yet present are executed. Skipped combos still populate the phase's working
+set (from JSONL data) so downstream phases see the full picture.
+
+Combo key per phase:
+- P0/P1: `ngl`
+- P2: `(fa, ctk, ctv)`
+- P3: `threads` (`"sys"` for system default)
+- P4: `nkvo`
+- P5: `(b, ub)`
+- P6: `ctx`
+- P7: `(ngl, fa, ctk, ctv, nkvo, threads, b, ub, ctx)`
+
+If all combos already exist, the phase completes immediately with working sets
+reconstructed from JSONL data.
 
 ### Estimating Phase 7 size before running
 

--- a/example.env
+++ b/example.env
@@ -113,6 +113,10 @@ SWEEP_COOL_POLL_SEC=20
 # Skip these phases (comma-separated). Equivalent to --skip-phases.
 # SWEEP_SKIP_PHASES=7
 
+# Only run combos not already in sweep.jsonl. Equivalent to --focused.
+# Requires --only-phases. Skipped combos still populate working sets for downstream phases.
+# SWEEP_FOCUSED=false
+
 # Path to a model list file (one filename per line). Equivalent to --model-list.
 # SWEEP_MODEL_LIST=~/bench_list.txt
 

--- a/output/jsonl.go
+++ b/output/jsonl.go
@@ -227,31 +227,41 @@ func LoadExistingCombos(outputDir string) (map[int]map[string]ExistingCombo, err
 	return result, scanner.Err()
 }
 
-// comboKey builds the dedup key for a given phase from JSONL params.
-func comboKey(phase int, p jsonlParamsJSON) string {
+// ComboKey builds the canonical dedup key for --focused mode.
+// Thread value is encoded as "sys" for system default (nil), or the integer value.
+func ComboKey(phase int, ngl, fa int, ctk, ctv string, nkvo int, threads *int, b, ub, ctx int) string {
 	switch phase {
 	case 0, 1:
-		return fmt.Sprintf("%d", p.NGL)
+		return fmt.Sprintf("%d", ngl)
 	case 2:
-		return fmt.Sprintf("%d_%s_%s", p.FA, p.CTK, p.CTV)
+		return fmt.Sprintf("%d_%s_%s", fa, ctk, ctv)
 	case 3:
-		if p.ThreadsIsDefault || p.Threads == nil {
+		if threads == nil {
 			return "sys"
 		}
-		return fmt.Sprintf("%d", *p.Threads)
+		return fmt.Sprintf("%d", *threads)
 	case 4:
-		return fmt.Sprintf("%d", p.NKVO)
+		return fmt.Sprintf("%d", nkvo)
 	case 5:
-		return fmt.Sprintf("%d_%d", p.B, p.UB)
+		return fmt.Sprintf("%d_%d", b, ub)
 	case 6:
-		return fmt.Sprintf("%d", p.NPrompt)
+		return fmt.Sprintf("%d", ctx)
 	case 7:
 		thr := "sys"
-		if !p.ThreadsIsDefault && p.Threads != nil {
-			thr = fmt.Sprintf("%d", *p.Threads)
+		if threads != nil {
+			thr = fmt.Sprintf("%d", *threads)
 		}
-		return fmt.Sprintf("%d_%d_%s_%s_%d_%s_%d_%d_%d", p.NGL, p.FA, p.CTK, p.CTV, p.NKVO, thr, p.B, p.UB, p.NPrompt)
+		return fmt.Sprintf("%d_%d_%s_%s_%d_%s_%d_%d_%d", ngl, fa, ctk, ctv, nkvo, thr, b, ub, ctx)
 	default:
 		return ""
 	}
+}
+
+// comboKey unpacks JSONL params and delegates to ComboKey.
+func comboKey(phase int, p jsonlParamsJSON) string {
+	var threads *int
+	if !p.ThreadsIsDefault && p.Threads != nil {
+		threads = p.Threads
+	}
+	return ComboKey(phase, p.NGL, p.FA, p.CTK, p.CTV, p.NKVO, threads, p.B, p.UB, p.NPrompt)
 }

--- a/output/jsonl.go
+++ b/output/jsonl.go
@@ -1,9 +1,12 @@
 package output
 
 import (
+	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/WagnerJust/llamaseye/bench"
@@ -153,4 +156,102 @@ func AppendRecord(outputDir, modelPath, modelStem string,
 	defer f.Close()
 	_, err = f.Write(line)
 	return err
+}
+
+// ExistingCombo holds performance data for a previously-tested combo.
+type ExistingCombo struct {
+	TG float64
+	PP float64
+}
+
+// LoadExistingCombos reads sweep.jsonl and returns combo keys for all status="ok"
+// records, indexed by phase ID. Each phase uses a different combo key format:
+//
+//	P0,P1: "ngl"
+//	P2:    "fa_ctk_ctv"
+//	P3:    "threads" or "sys"
+//	P4:    "nkvo"
+//	P5:    "b_ub"
+//	P6:    "ctx"
+//	P7:    "ngl_fa_ctk_ctv_nkvo_threads_b_ub_ctx"
+func LoadExistingCombos(outputDir string) (map[int]map[string]ExistingCombo, error) {
+	path := filepath.Join(outputDir, "sweep.jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	result := make(map[int]map[string]ExistingCombo)
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var rec JSONLRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec.Status != "ok" {
+			continue
+		}
+
+		key := comboKey(rec.Phase, rec.Params)
+		if key == "" {
+			continue
+		}
+
+		if result[rec.Phase] == nil {
+			result[rec.Phase] = make(map[string]ExistingCombo)
+		}
+
+		// Extract TG/PP from results
+		var tg, pp float64
+		for _, r := range rec.Results {
+			switch r.Test {
+			case "tg":
+				tg = r.AvgTS
+			case "pp":
+				pp = r.AvgTS
+			}
+		}
+
+		// Keep the best TG for each combo key
+		if existing, ok := result[rec.Phase][key]; !ok || tg > existing.TG {
+			result[rec.Phase][key] = ExistingCombo{TG: tg, PP: pp}
+		}
+	}
+	return result, scanner.Err()
+}
+
+// comboKey builds the dedup key for a given phase from JSONL params.
+func comboKey(phase int, p jsonlParamsJSON) string {
+	switch phase {
+	case 0, 1:
+		return fmt.Sprintf("%d", p.NGL)
+	case 2:
+		return fmt.Sprintf("%d_%s_%s", p.FA, p.CTK, p.CTV)
+	case 3:
+		if p.ThreadsIsDefault || p.Threads == nil {
+			return "sys"
+		}
+		return fmt.Sprintf("%d", *p.Threads)
+	case 4:
+		return fmt.Sprintf("%d", p.NKVO)
+	case 5:
+		return fmt.Sprintf("%d_%d", p.B, p.UB)
+	case 6:
+		return fmt.Sprintf("%d", p.NPrompt)
+	case 7:
+		thr := "sys"
+		if !p.ThreadsIsDefault && p.Threads != nil {
+			thr = fmt.Sprintf("%d", *p.Threads)
+		}
+		return fmt.Sprintf("%d_%d_%s_%s_%d_%s_%d_%d_%d", p.NGL, p.FA, p.CTK, p.CTV, p.NKVO, thr, p.B, p.UB, p.NPrompt)
+	default:
+		return ""
+	}
 }

--- a/phase/common.go
+++ b/phase/common.go
@@ -2,7 +2,6 @@ package phase
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/WagnerJust/llamaseye/bench"
 	"github.com/WagnerJust/llamaseye/output"
@@ -208,36 +207,6 @@ func ShouldSkip(env *PhaseEnv, phaseID int, comboKey string) (output.ExistingCom
 		}
 	}
 	return output.ExistingCombo{}, false
-}
-
-// FocusedComboKey builds the combo key string for --focused dedup.
-// Thread value is encoded as "sys" for system default, or the integer value.
-func FocusedComboKey(phaseID int, ngl, fa int, ctk, ctv string, nkvo int, threads *int, b, ub, ctx int) string {
-	switch phaseID {
-	case 0, 1:
-		return fmt.Sprintf("%d", ngl)
-	case 2:
-		return fmt.Sprintf("%d_%s_%s", fa, ctk, ctv)
-	case 3:
-		if threads == nil {
-			return "sys"
-		}
-		return fmt.Sprintf("%d", *threads)
-	case 4:
-		return fmt.Sprintf("%d", nkvo)
-	case 5:
-		return fmt.Sprintf("%d_%d", b, ub)
-	case 6:
-		return fmt.Sprintf("%d", ctx)
-	case 7:
-		thr := "sys"
-		if threads != nil {
-			thr = fmt.Sprintf("%d", *threads)
-		}
-		return fmt.Sprintf("%d_%d_%s_%s_%d_%s_%d_%d_%d", ngl, fa, ctk, ctv, nkvo, thr, b, ub, ctx)
-	default:
-		return ""
-	}
 }
 
 // RecordAndTrack runs a bench and writes the JSONL record.

--- a/phase/common.go
+++ b/phase/common.go
@@ -2,6 +2,7 @@ package phase
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/WagnerJust/llamaseye/bench"
 	"github.com/WagnerJust/llamaseye/output"
@@ -191,6 +192,52 @@ func FindFACTKByKV(ws []state.FACTKCombo, ctk, ctv string) (fa int, found bool) 
 		}
 	}
 	return
+}
+
+// ShouldSkip returns true and the existing combo data if --focused is active
+// and this combo was already successfully tested in sweep.jsonl.
+func ShouldSkip(env *PhaseEnv, phaseID int, comboKey string) (output.ExistingCombo, bool) {
+	if !env.Config.Focused || env.SkipCombos == nil {
+		return output.ExistingCombo{}, false
+	}
+	if phaseMap, ok := env.SkipCombos[phaseID]; ok {
+		if combo, found := phaseMap[comboKey]; found {
+			env.Logger.Debugf("[Phase %d] --focused: skipping %s (already in sweep.jsonl, TG=%.2f)",
+				phaseID, comboKey, combo.TG)
+			return combo, true
+		}
+	}
+	return output.ExistingCombo{}, false
+}
+
+// FocusedComboKey builds the combo key string for --focused dedup.
+// Thread value is encoded as "sys" for system default, or the integer value.
+func FocusedComboKey(phaseID int, ngl, fa int, ctk, ctv string, nkvo int, threads *int, b, ub, ctx int) string {
+	switch phaseID {
+	case 0, 1:
+		return fmt.Sprintf("%d", ngl)
+	case 2:
+		return fmt.Sprintf("%d_%s_%s", fa, ctk, ctv)
+	case 3:
+		if threads == nil {
+			return "sys"
+		}
+		return fmt.Sprintf("%d", *threads)
+	case 4:
+		return fmt.Sprintf("%d", nkvo)
+	case 5:
+		return fmt.Sprintf("%d_%d", b, ub)
+	case 6:
+		return fmt.Sprintf("%d", ctx)
+	case 7:
+		thr := "sys"
+		if threads != nil {
+			thr = fmt.Sprintf("%d", *threads)
+		}
+		return fmt.Sprintf("%d_%d_%s_%s_%d_%s_%d_%d_%d", ngl, fa, ctk, ctv, nkvo, thr, b, ub, ctx)
+	default:
+		return ""
+	}
 }
 
 // RecordAndTrack runs a bench and writes the JSONL record.

--- a/phase/p1_ngl_sweep.go
+++ b/phase/p1_ngl_sweep.go
@@ -61,6 +61,16 @@ func (P1NGLSweep) Run(ctx context.Context, env *PhaseEnv) error {
 		default:
 		}
 
+		comboKey := fmt.Sprintf("%d", ngl)
+		if existing, skip := ShouldSkip(env, 1, comboKey); skip {
+			env.WS.NGL = append(env.WS.NGL, ngl)
+			if existing.TG > bestTG {
+				bestTG = existing.TG
+				env.Best.NGL = ngl
+			}
+			continue
+		}
+
 		status, tg, _ := RecordAndTrack(env, fmt.Sprintf("phase1/ngl=%d", ngl), bench.RunParams{
 			NGL:        ngl,
 			FA:         0,

--- a/phase/p2_fa_kv_sweep.go
+++ b/phase/p2_fa_kv_sweep.go
@@ -140,6 +140,22 @@ func (P2FAKVSweep) Run(ctx context.Context, env *PhaseEnv) error {
 			continue
 		}
 
+		comboKey := fmt.Sprintf("%d_%s_%s", combo.FA, combo.CTK, combo.CTV)
+		if existing, skip := ShouldSkip(env, 2, comboKey); skip {
+			env.WS.FACTK = append(env.WS.FACTK, state.FACTKCombo{
+				FA:  combo.FA,
+				CTK: combo.CTK,
+				CTV: combo.CTV,
+			})
+			if existing.TG > bestTG {
+				bestTG = existing.TG
+				env.Best.FA = combo.FA
+				env.Best.CTK = combo.CTK
+				env.Best.CTV = combo.CTV
+			}
+			continue
+		}
+
 		label := fmt.Sprintf("phase2/fa=%d_ctk=%s_ctv=%s", combo.FA, combo.CTK, combo.CTV)
 		status, tg, _ := RecordAndTrack(env, label, bench.RunParams{
 			NGL:        env.Best.NGL,

--- a/phase/p3_thread_sweep.go
+++ b/phase/p3_thread_sweep.go
@@ -44,25 +44,32 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 	env.WS.Threads = nil
 
 	// System default run first (no -t flag)
-	status, tg, _ := RecordAndTrack(env, "phase3/threads=system_default", bench.RunParams{
-		NGL:        env.Best.NGL,
-		FA:         env.Best.FA,
-		CTK:        env.Best.CTK,
-		CTV:        env.Best.CTV,
-		NKVO:       0,
-		B:          env.Best.B,
-		UB:         env.Best.UB,
-		NPrompt:    512,
-		NGen:       128,
-		Reps:       env.Config.Repetitions,
-		Phase:      3,
-		PhaseLabel: "thread_sweep",
-	})
-	if status == bench.StatusOK {
+	if existing, skip := ShouldSkip(env, 3, "sys"); skip {
 		env.WS.Threads = append(env.WS.Threads, "system_default")
-		if tg > bestTG {
-			bestTG = tg
-			// system default → leave env.Best.Threads nil
+		if existing.TG > bestTG {
+			bestTG = existing.TG
+		}
+	} else {
+		status, tg, _ := RecordAndTrack(env, "phase3/threads=system_default", bench.RunParams{
+			NGL:        env.Best.NGL,
+			FA:         env.Best.FA,
+			CTK:        env.Best.CTK,
+			CTV:        env.Best.CTV,
+			NKVO:       0,
+			B:          env.Best.B,
+			UB:         env.Best.UB,
+			NPrompt:    512,
+			NGen:       128,
+			Reps:       env.Config.Repetitions,
+			Phase:      3,
+			PhaseLabel: "thread_sweep",
+		})
+		if status == bench.StatusOK {
+			env.WS.Threads = append(env.WS.Threads, "system_default")
+			if tg > bestTG {
+				bestTG = tg
+				// system default → leave env.Best.Threads nil
+			}
 		}
 	}
 
@@ -71,6 +78,17 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+		}
+
+		comboKey := fmt.Sprintf("%d", t)
+		if existing, skip := ShouldSkip(env, 3, comboKey); skip {
+			env.WS.Threads = append(env.WS.Threads, t)
+			if existing.TG > bestTG {
+				bestTG = existing.TG
+				tc := t
+				env.Best.Threads = &tc
+			}
+			continue
 		}
 
 		tc := t // capture

--- a/phase/p4_nkvo_sweep.go
+++ b/phase/p4_nkvo_sweep.go
@@ -25,6 +25,16 @@ func (P4NKVOSweep) Run(ctx context.Context, env *PhaseEnv) error {
 		default:
 		}
 
+		comboKey := fmt.Sprintf("%d", nkvo)
+		if existing, skip := ShouldSkip(env, 4, comboKey); skip {
+			env.WS.NKVO = append(env.WS.NKVO, nkvo)
+			if existing.TG > bestTG {
+				bestTG = existing.TG
+				env.Best.NKVO = nkvo
+			}
+			continue
+		}
+
 		status, tg, _ := RecordAndTrack(env, fmt.Sprintf("phase4/nkvo=%d", nkvo), bench.RunParams{
 			NGL:        env.Best.NGL,
 			FA:         env.Best.FA,

--- a/phase/p5_batch_sweep.go
+++ b/phase/p5_batch_sweep.go
@@ -60,6 +60,17 @@ func (P5BatchSweep) Run(ctx context.Context, env *PhaseEnv) error {
 			continue
 		}
 
+		comboKey := fmt.Sprintf("%d_%d", pair.B, pair.UB)
+		if existing, skip := ShouldSkip(env, 5, comboKey); skip {
+			env.WS.BUB = append(env.WS.BUB, pair)
+			if existing.PP > bestPP {
+				bestPP = existing.PP
+				env.Best.B = pair.B
+				env.Best.UB = pair.UB
+			}
+			continue
+		}
+
 		label := fmt.Sprintf("phase5/b=%d_ub=%d", pair.B, pair.UB)
 		status, _, pp := RecordAndTrack(env, label, bench.RunParams{
 			NGL:        env.Best.NGL,

--- a/phase/p6_ctx_sweep.go
+++ b/phase/p6_ctx_sweep.go
@@ -50,6 +50,13 @@ func (P6CtxSweep) Run(ctx context.Context, env *PhaseEnv) error {
 		default:
 		}
 
+		comboKey := fmt.Sprintf("%d", ctxVal)
+		if _, skip := ShouldSkip(env, 6, comboKey); skip {
+			env.WS.CTX = appendIfMissing(env.WS.CTX, ctxVal)
+			env.Best.CTX = ctxVal
+			continue
+		}
+
 		result := p6TryCtx(ctx, env, ctxVal, kvQualityOrder, bestCTKIdx, bestCTVIdx)
 
 		if result == "ok" {

--- a/phase/p7_combination_matrix.go
+++ b/phase/p7_combination_matrix.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/WagnerJust/llamaseye/bench"
+	"github.com/WagnerJust/llamaseye/output"
 	"github.com/WagnerJust/llamaseye/state"
 )
 
@@ -90,6 +91,7 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 	ctxCeil := make(map[string]int)
 
 	runCount := 0
+	skipCount := 0
 	goalHits := 0
 	goalDone := false
 	// goalTuples tracks best TG seen per (ngl,ctk,nkvo,ctx) key.
@@ -154,9 +156,9 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 									threads = &tc
 								}
 
-								p7Key := FocusedComboKey(7, ngl, fa, ctk, ctv, nkvo, threads, bub.B, bub.UB, ctxVal)
+								p7Key := output.ComboKey(7, ngl, fa, ctk, ctv, nkvo, threads, bub.B, bub.UB, ctxVal)
 								if _, skip := ShouldSkip(env, 7, p7Key); skip {
-									runCount++
+									skipCount++
 									continue
 								}
 
@@ -181,7 +183,11 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 
 								runCount++
 								if runCount%10 == 0 {
-									env.Logger.Log("[Phase 7] %d/%d combinations run", runCount, total)
+									if skipCount > 0 {
+										env.Logger.Log("[Phase 7] %d/%d combinations run (%d skipped via --focused)", runCount, total, skipCount)
+									} else {
+										env.Logger.Log("[Phase 7] %d/%d combinations run", runCount, total)
+									}
 								}
 
 								if status == bench.StatusOOM || status == bench.StatusTimeout {
@@ -236,10 +242,19 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 	}
 
 	if p.Goal != nil {
-		env.Logger.Log("[Phase 7] Complete — %d combinations run, %d/%d distinct goal configs found",
-			runCount, goalHits, p.Goal.MaxHits)
+		if skipCount > 0 {
+			env.Logger.Log("[Phase 7] Complete — %d combinations run, %d skipped via --focused, %d/%d distinct goal configs found",
+				runCount, skipCount, goalHits, p.Goal.MaxHits)
+		} else {
+			env.Logger.Log("[Phase 7] Complete — %d combinations run, %d/%d distinct goal configs found",
+				runCount, goalHits, p.Goal.MaxHits)
+		}
 	} else {
-		env.Logger.Log("[Phase 7] Complete — %d combinations run", runCount)
+		if skipCount > 0 {
+			env.Logger.Log("[Phase 7] Complete — %d combinations run, %d skipped via --focused", runCount, skipCount)
+		} else {
+			env.Logger.Log("[Phase 7] Complete — %d combinations run", runCount)
+		}
 	}
 	return nil
 }

--- a/phase/p7_combination_matrix.go
+++ b/phase/p7_combination_matrix.go
@@ -147,15 +147,21 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 								default:
 								}
 
-								label := fmt.Sprintf("p7/ngl=%d_fa=%d_ctk=%s_ctv=%s_nkvo=%d_b=%d_ub=%d_ctx=%d",
-									ngl, fa, ctk, ctv, nkvo, bub.B, bub.UB, ctxVal)
-
 								var threads *int
 								switch t := threadVal.(type) {
 								case int:
 									tc := t
 									threads = &tc
 								}
+
+								p7Key := FocusedComboKey(7, ngl, fa, ctk, ctv, nkvo, threads, bub.B, bub.UB, ctxVal)
+								if _, skip := ShouldSkip(env, 7, p7Key); skip {
+									runCount++
+									continue
+								}
+
+								label := fmt.Sprintf("p7/ngl=%d_fa=%d_ctk=%s_ctv=%s_nkvo=%d_b=%d_ub=%d_ctx=%d",
+									ngl, fa, ctk, ctv, nkvo, bub.B, bub.UB, ctxVal)
 
 								status, tg, pp := RecordAndTrack(env, label, bench.RunParams{
 									NGL:        ngl,

--- a/phase/phase.go
+++ b/phase/phase.go
@@ -57,6 +57,10 @@ type PhaseEnv struct {
 	OutputDir  string
 	ModelPath  string
 	ModelStem  string
+
+	// SkipCombos holds combo keys from sweep.jsonl when --focused is active.
+	// Keyed by phase ID → combo key string → performance data.
+	SkipCombos map[int]map[string]output.ExistingCombo
 }
 
 // NewPhaseEnv creates a PhaseEnv with default best values.

--- a/sweep/orchestrator.go
+++ b/sweep/orchestrator.go
@@ -121,6 +121,20 @@ func (s *Sweeper) SweepModel(ctx context.Context, modelPath string) error {
 		}
 	}
 
+	// --focused: load existing combos from sweep.jsonl for dedup
+	if s.Config.Focused {
+		combos, err := output.LoadExistingCombos(outputDir)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("--focused: load sweep.jsonl: %w", err)
+		}
+		env.SkipCombos = combos
+		total := 0
+		for _, m := range combos {
+			total += len(m)
+		}
+		s.Logger.Log("[FOCUSED] Loaded %d existing combos from sweep.jsonl", total)
+	}
+
 	// Build goal config
 	var goal *phase.GoalConfig
 	if s.Config.Goal != "" {

--- a/sweep/orchestrator.go
+++ b/sweep/orchestrator.go
@@ -3,6 +3,7 @@ package sweep
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -124,7 +125,7 @@ func (s *Sweeper) SweepModel(ctx context.Context, modelPath string) error {
 	// --focused: load existing combos from sweep.jsonl for dedup
 	if s.Config.Focused {
 		combos, err := output.LoadExistingCombos(outputDir)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("--focused: load sweep.jsonl: %w", err)
 		}
 		env.SkipCombos = combos


### PR DESCRIPTION
## Summary
- Adds `--focused` flag (env: `SWEEP_FOCUSED`) that, when combined with `--only-phases`, diffs each phase's planned combos against existing `status: "ok"` entries in `sweep.jsonl` and only runs combos not yet present
- Skipped combos still populate working sets (with TG/PP data from JSONL) so downstream phases see the full picture
- Phase 0 (NGL probe) is excluded — binary search logic can't skip mid-probe

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `--focused` without `--only-phases` returns a validation error
- [ ] Run Phase 2 on a model, then re-run with `--only-phases 2 --focused` — all combos skipped, working sets reconstructed
- [ ] Add new asymmetric combos (e.g. enable `--asymmetric-kv`), re-run with `--only-phases 2 --focused` — only new combos run
- [ ] Re-run Phase 7 with `--only-phases 7 --focused` after Phase 2 focused run — Phase 7 sees full working set

🤖 Generated with [Claude Code](https://claude.com/claude-code)