### PR TITLE
feat: signal handling & context propagation

### DIFF
--- a/.claude/skills/llamaseye/SKILL.md
+++ b/.claude/skills/llamaseye/SKILL.md
@@ -72,7 +72,7 @@ cd ~/Src/llamaseye && ./llamaseye --model ~/Models/model.gguf \
 cd ~/Src/llamaseye && ./llamaseye --model ~/Models/model.gguf \
   --rotor-bench ~/llama-cpp-rotorquant/build/bin/llama-bench
 
-# Resume an interrupted sweep
+# Resume an interrupted sweep (Ctrl-C saves state automatically)
 cd ~/Src/llamaseye && ./llamaseye --model ~/Models/model.gguf --resume
 
 # Run only specific phases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `.github/ISSUE_TEMPLATE/` with bug report and feature request templates.
 - `.github/pull_request_template.md` with doc-update checklist.
 - `Makefile` with `build`, `test`, `vet`, `lint`, and `clean` targets.
+- **Graceful shutdown on SIGINT/SIGTERM** — pressing Ctrl-C now cancels the in-flight benchmark, saves `state.json`, and exits cleanly. Use `--resume` to continue from where it stopped.
+- Context propagation through the full call chain: `main.go` → `SweepModel` → `Phase.Run` → `RecordAndTrack` → `WaitCool` + `RunBench`. All `ctx.Done()` checks in phase loops are now functional.
+- `RunBench` accepts a parent `context.Context`, allowing in-flight subprocesses to be cancelled on signal.
+- `WaitCool` now respects the caller's context instead of using a detached `context.Background()`.
 
 ### Fixed
 - Thermal monitor on Linux: shell pipeline commands (containing `|`, `>`, `<`) are now dispatched via `sh -c` instead of `strings.Fields` splitting. Previously, `sensors ... | awk ...` was passed as literal arguments to `sensors`, making the thermal guard a silent no-op on Linux AMD/Intel hardware.

--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ results/
 
 `sweep.jsonl` is append-only and is the source of truth. `state.json` tracks which phases are complete and the best parameter values discovered so far, enabling `--resume` to pick up exactly where it left off.
 
+**Graceful shutdown:** Pressing Ctrl-C (or sending SIGTERM) cancels the current run, saves `state.json`, and exits cleanly. Use `--resume` to continue from where it stopped.
+
 **`sweep.md` sections:**
 - **Best Configurations** — top 10 results across all phases ranked by TG t/s
 - **Per-phase tables** — all runs for each phase, sorted by TG t/s, with a `> **Winner:**` callout line showing the best config for that axis

--- a/bench/runner.go
+++ b/bench/runner.go
@@ -59,7 +59,9 @@ type llamaBenchLine struct {
 }
 
 // RunBench executes a single llama-bench invocation and returns the result.
-func (r *BenchRunner) RunBench(label string, p RunParams) (*RunResult, error) {
+// The provided ctx is used as the parent for the per-run timeout, allowing
+// callers to cancel in-flight benchmarks (e.g. on SIGINT).
+func (r *BenchRunner) RunBench(ctx context.Context, label string, p RunParams) (*RunResult, error) {
 	binary, binaryLabel, err := r.Selector.Select(p.CTK, p.CTV)
 	if err != nil {
 		return nil, err
@@ -111,7 +113,7 @@ func (r *BenchRunner) RunBench(label string, p RunParams) (*RunResult, error) {
 	}
 
 	var stdoutBuf, stderrBuf bytes.Buffer
-	ctx, cancel := context.WithTimeout(context.Background(),
+	ctx, cancel := context.WithTimeout(ctx,
 		time.Duration(r.Config.TimeoutSec)*time.Second)
 	defer cancel()
 

--- a/bench/runner_test.go
+++ b/bench/runner_test.go
@@ -62,7 +62,7 @@ func TestRunBench_OK(t *testing.T) {
 	exec := &mockExecutor{stdout: stdout}
 	r := newTestRunner(t, exec)
 
-	res, err := r.RunBench("test", RunParams{
+	res, err := r.RunBench(context.Background(), "test", RunParams{
 		NGL: 20, FA: 1, CTK: "f16", CTV: "f16", NKVO: 0,
 		B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 3,
 		Phase: 1, PhaseLabel: "ngl_sweep",
@@ -88,7 +88,7 @@ func TestRunBench_OOM(t *testing.T) {
 	}
 	r := newTestRunner(t, exec)
 
-	res, err := r.RunBench("test", RunParams{
+	res, err := r.RunBench(context.Background(), "test", RunParams{
 		NGL: 99, FA: 0, CTK: "f16", CTV: "f16",
 		B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 1,
 	})
@@ -104,7 +104,7 @@ func TestRunBench_Timeout(t *testing.T) {
 	exec := &mockExecutor{slowTimeout: true}
 	r := newTestRunner(t, exec)
 
-	res, err := r.RunBench("test", RunParams{
+	res, err := r.RunBench(context.Background(), "test", RunParams{
 		NGL: 20, FA: 0, CTK: "f16", CTV: "f16",
 		B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 1,
 	})
@@ -124,7 +124,7 @@ func TestRunBench_Error(t *testing.T) {
 	}
 	r := newTestRunner(t, exec)
 
-	res, err := r.RunBench("test", RunParams{
+	res, err := r.RunBench(context.Background(), "test", RunParams{
 		NGL: 20, FA: 0, CTK: "f16", CTV: "f16",
 		B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 1,
 	})
@@ -141,7 +141,7 @@ func TestRunBench_DryRun(t *testing.T) {
 	r := newTestRunner(t, exec)
 	r.Config.DryRun = true
 
-	res, err := r.RunBench("test", RunParams{NGL: 20, CTK: "f16", CTV: "f16", B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 1})
+	res, err := r.RunBench(context.Background(), "test", RunParams{NGL: 20, CTK: "f16", CTV: "f16", B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 1})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestRunBench_TurboUnavailable(t *testing.T) {
 	r.Selector.TurboAvailable = false
 
 	// turbo type with unavailable turbo binary should error or return error status
-	res, err := r.RunBench("test-turbo", RunParams{CTK: "turbo3", CTV: "f16", NGL: 20, B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 1})
+	res, err := r.RunBench(context.Background(), "test-turbo", RunParams{CTK: "turbo3", CTV: "f16", NGL: 20, B: 2048, UB: 512, NPrompt: 512, NGen: 128, Reps: 1})
 	if err == nil && (res == nil || res.Status != StatusError) {
 		t.Error("expected error or error status for turbo with unavailable binary")
 	}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -953,6 +953,24 @@ for short runs that don't push thermals.
 
 ---
 
+## Signal Handling & Graceful Shutdown
+
+The binary registers a signal handler for `SIGINT` and `SIGTERM` via
+`signal.NotifyContext`. When a signal is received:
+
+1. The root context is cancelled.
+2. Any in-flight `llama-bench` subprocess is killed (the per-run timeout
+   context inherits from the root context).
+3. Thermal `WaitCool` loops exit immediately.
+4. The current phase loop exits via `ctx.Done()`.
+5. `state.json` is saved with all phases completed so far, enabling
+   `--resume` to pick up where the sweep left off.
+
+Context flows: `main.go` → `SweepModel(ctx)` → `Phase.Run(ctx)` →
+`RecordAndTrack(ctx)` → `WaitCool(ctx)` + `RunBench(ctx)`.
+
+---
+
 ## Output Format & File Layout
 
 ### Directory structure

--- a/main.go
+++ b/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/WagnerJust/llamaseye/bench"
 	"github.com/WagnerJust/llamaseye/cmd"
@@ -130,10 +132,16 @@ func run(args []string) error {
 		Executor: bench.OSExecutor{},
 	}
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	var swept []string
 	for _, modelPath := range models {
 		if err := s.SweepModel(ctx, modelPath); err != nil {
+			if ctx.Err() != nil {
+				logger.Log("Interrupted — saving state and exiting")
+				break
+			}
 			logger.Warn("sweep failed for %s: %v", modelPath, err)
 			continue
 		}

--- a/phase/common.go
+++ b/phase/common.go
@@ -210,13 +210,15 @@ func ShouldSkip(env *PhaseEnv, phaseID int, comboKey string) (output.ExistingCom
 }
 
 // RecordAndTrack runs a bench and writes the JSONL record.
+// The provided ctx is forwarded to WaitCool and RunBench, allowing
+// graceful cancellation on SIGINT/SIGTERM.
 // Returns the status and the TG t/s (0 if not available).
-func RecordAndTrack(env *PhaseEnv, label string, p bench.RunParams) (bench.Status, float64, float64) {
+func RecordAndTrack(ctx context.Context, env *PhaseEnv, label string, p bench.RunParams) (bench.Status, float64, float64) {
 	if env.Thermal != nil {
-		env.Thermal.WaitCool(context.Background())
+		env.Thermal.WaitCool(ctx)
 	}
 
-	res, err := env.Runner.RunBench(label, p)
+	res, err := env.Runner.RunBench(ctx, label, p)
 	if err != nil {
 		env.Logger.Warn("RunBench error for %s: %v", label, err)
 		return bench.StatusError, 0, 0

--- a/phase/p0_ngl_probe.go
+++ b/phase/p0_ngl_probe.go
@@ -37,7 +37,7 @@ func (P0NGLProbe) Run(ctx context.Context, env *PhaseEnv) error {
 		}
 
 		env.Logger.Log("[Phase 0] Probing ngl=%d", ngl)
-		status, _, _ := RecordAndTrack(env, "phase0/ngl="+itoa(ngl), bench.RunParams{
+		status, _, _ := RecordAndTrack(ctx, env, "phase0/ngl="+itoa(ngl), bench.RunParams{
 			NGL:        ngl,
 			FA:         0,
 			CTK:        "f16",

--- a/phase/p1_ngl_sweep.go
+++ b/phase/p1_ngl_sweep.go
@@ -71,7 +71,7 @@ func (P1NGLSweep) Run(ctx context.Context, env *PhaseEnv) error {
 			continue
 		}
 
-		status, tg, _ := RecordAndTrack(env, fmt.Sprintf("phase1/ngl=%d", ngl), bench.RunParams{
+		status, tg, _ := RecordAndTrack(ctx, env, fmt.Sprintf("phase1/ngl=%d", ngl), bench.RunParams{
 			NGL:        ngl,
 			FA:         0,
 			CTK:        "f16",

--- a/phase/p2_fa_kv_sweep.go
+++ b/phase/p2_fa_kv_sweep.go
@@ -157,7 +157,7 @@ func (P2FAKVSweep) Run(ctx context.Context, env *PhaseEnv) error {
 		}
 
 		label := fmt.Sprintf("phase2/fa=%d_ctk=%s_ctv=%s", combo.FA, combo.CTK, combo.CTV)
-		status, tg, _ := RecordAndTrack(env, label, bench.RunParams{
+		status, tg, _ := RecordAndTrack(ctx, env, label, bench.RunParams{
 			NGL:        env.Best.NGL,
 			FA:         combo.FA,
 			CTK:        combo.CTK,

--- a/phase/p3_thread_sweep.go
+++ b/phase/p3_thread_sweep.go
@@ -50,7 +50,7 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 			bestTG = existing.TG
 		}
 	} else {
-		status, tg, _ := RecordAndTrack(env, "phase3/threads=system_default", bench.RunParams{
+		status, tg, _ := RecordAndTrack(ctx, env, "phase3/threads=system_default", bench.RunParams{
 			NGL:        env.Best.NGL,
 			FA:         env.Best.FA,
 			CTK:        env.Best.CTK,
@@ -92,7 +92,7 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 		}
 
 		tc := t // capture
-		status, tg, _ := RecordAndTrack(env, fmt.Sprintf("phase3/threads=%d", t), bench.RunParams{
+		status, tg, _ := RecordAndTrack(ctx, env, fmt.Sprintf("phase3/threads=%d", t), bench.RunParams{
 			NGL:        env.Best.NGL,
 			FA:         env.Best.FA,
 			CTK:        env.Best.CTK,

--- a/phase/p4_nkvo_sweep.go
+++ b/phase/p4_nkvo_sweep.go
@@ -35,7 +35,7 @@ func (P4NKVOSweep) Run(ctx context.Context, env *PhaseEnv) error {
 			continue
 		}
 
-		status, tg, _ := RecordAndTrack(env, fmt.Sprintf("phase4/nkvo=%d", nkvo), bench.RunParams{
+		status, tg, _ := RecordAndTrack(ctx, env, fmt.Sprintf("phase4/nkvo=%d", nkvo), bench.RunParams{
 			NGL:        env.Best.NGL,
 			FA:         env.Best.FA,
 			CTK:        env.Best.CTK,
@@ -70,7 +70,7 @@ func (P4NKVOSweep) Run(ctx context.Context, env *PhaseEnv) error {
 				return ctx.Err()
 			default:
 			}
-			status, _, _ := RecordAndTrack(env, fmt.Sprintf("phase4/nkvo=1_ngl=%d", extra), bench.RunParams{
+			status, _, _ := RecordAndTrack(ctx, env, fmt.Sprintf("phase4/nkvo=1_ngl=%d", extra), bench.RunParams{
 				NGL:        extra,
 				FA:         env.Best.FA,
 				CTK:        env.Best.CTK,

--- a/phase/p5_batch_sweep.go
+++ b/phase/p5_batch_sweep.go
@@ -72,7 +72,7 @@ func (P5BatchSweep) Run(ctx context.Context, env *PhaseEnv) error {
 		}
 
 		label := fmt.Sprintf("phase5/b=%d_ub=%d", pair.B, pair.UB)
-		status, _, pp := RecordAndTrack(env, label, bench.RunParams{
+		status, _, pp := RecordAndTrack(ctx, env, label, bench.RunParams{
 			NGL:        env.Best.NGL,
 			FA:         env.Best.FA,
 			CTK:        env.Best.CTK,

--- a/phase/p6_ctx_sweep.go
+++ b/phase/p6_ctx_sweep.go
@@ -119,7 +119,7 @@ func p6TryCtx(ctx context.Context, env *PhaseEnv, ctxVal int,
 	kvOrder []string, bestCTKIdx, bestCTVIdx int) string {
 
 	// Primary config
-	status, _, _ := RecordAndTrack(env, fmt.Sprintf("phase6/ctx=%d", ctxVal), bench.RunParams{
+	status, _, _ := RecordAndTrack(ctx, env, fmt.Sprintf("phase6/ctx=%d", ctxVal), bench.RunParams{
 		NGL:        env.Best.NGL,
 		FA:         env.Best.FA,
 		CTK:        env.Best.CTK,
@@ -223,7 +223,7 @@ func p6TryCtx(ctx context.Context, env *PhaseEnv, ctxVal int,
 		}
 
 		label := fmt.Sprintf("phase6/ctx=%d/nkvo=%d_ctk=%s_ctv=%s", ctxVal, fb.NKVO, fb.CTK, fb.CTV)
-		fbStatus, _, _ := RecordAndTrack(env, label, bench.RunParams{
+		fbStatus, _, _ := RecordAndTrack(ctx, env, label, bench.RunParams{
 			NGL:        env.Best.NGL,
 			FA:         fb.FA,
 			CTK:        fb.CTK,

--- a/phase/p7_combination_matrix.go
+++ b/phase/p7_combination_matrix.go
@@ -165,7 +165,7 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 								label := fmt.Sprintf("p7/ngl=%d_fa=%d_ctk=%s_ctv=%s_nkvo=%d_b=%d_ub=%d_ctx=%d",
 									ngl, fa, ctk, ctv, nkvo, bub.B, bub.UB, ctxVal)
 
-								status, tg, pp := RecordAndTrack(env, label, bench.RunParams{
+								status, tg, pp := RecordAndTrack(ctx, env, label, bench.RunParams{
 									NGL:        ngl,
 									FA:         fa,
 									CTK:        ctk,


### PR DESCRIPTION
## Summary
- Register `SIGINT`/`SIGTERM` handler via `signal.NotifyContext` in `main.go` so Ctrl-C triggers graceful shutdown
- `RunBench` now accepts a parent `context.Context` (timeout derived from it, not `context.Background()`)
- `RecordAndTrack` now accepts and forwards `ctx` to both `WaitCool` and `RunBench`
- All `ctx.Done()` checks in phase loops are now functional — previously they were dead code

Closes #40

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes (all 8 test packages)
- [ ] Manual test: start a sweep, press Ctrl-C, verify state.json is saved and `--resume` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)