### PR TITLE
fix: stop silently discarding errors in AppendRecord, parseErr, and bufio.Flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - GGUF parser: added upper-bound checks on key length (64 KiB), string length (1 MiB), and array length (1M elements) before allocating. A malformed `.gguf` file can no longer exhaust RAM via oversized `make()` calls.
 - README.md: corrected stale `bash llamaseye.sh --report` reference to `./llamaseye --report`.
 - `go.mod`: removed incorrect `// indirect` comment on `pflag` (direct dependency).
+- `AppendRecord` errors are now logged as warnings instead of silently discarded — prevents silent data loss when disk is full or output dir becomes unwritable.
+- `parseLlamaBenchOutput` errors are logged at debug level; empty results with zero exit code now returns `StatusError` instead of `StatusOK` with no throughput data.
+- `bufio.Writer.Flush()` errors in `GenerateMarkdown` and `GenerateCrossModelSummary` are now captured via named return values instead of silently dropped by `defer w.Flush()`.
 
 ---
 

--- a/bench/runner.go
+++ b/bench/runner.go
@@ -174,7 +174,24 @@ func (r *BenchRunner) RunBench(ctx context.Context, label string, p RunParams) (
 		}, nil
 	}
 
-	_ = parseErr
+	// Empty results with zero exit = parse failure (malformed output)
+	if parseErr != nil || (len(results) == 0 && exitCode == 0) {
+		errMsg := "no results parsed from llama-bench output"
+		if parseErr != nil {
+			errMsg = parseErr.Error()
+		}
+		if r.Logger != nil {
+			r.Logger.Debugf("parse issue: %s", errMsg)
+		}
+		if len(results) == 0 {
+			return &RunResult{
+				RunID:        runID,
+				Status:       StatusError,
+				WallTimeSec:  wallTime,
+				ErrorSnippet: errMsg,
+			}, nil
+		}
+	}
 
 	return &RunResult{
 		RunID:         runID,

--- a/output/markdown.go
+++ b/output/markdown.go
@@ -97,7 +97,7 @@ func loadJSONL(path string) ([]*record, error) {
 // GenerateMarkdown writes sweep.md from sweep.jsonl in outputDir.
 // goalSpec is the raw --goal string (may be empty).
 // goalSort controls the sort key for the Goal Results table: "tg"|"ctx"|"ngl"|"pp".
-func GenerateMarkdown(outputDir, modelStem, goalSpec, goalSort string, timeoutSec int) error {
+func GenerateMarkdown(outputDir, modelStem, goalSpec, goalSort string, timeoutSec int) (err error) {
 	jsonlPath := filepath.Join(outputDir, "sweep.jsonl")
 	if _, err := os.Stat(jsonlPath); os.IsNotExist(err) {
 		return nil
@@ -116,7 +116,11 @@ func GenerateMarkdown(outputDir, modelStem, goalSpec, goalSort string, timeoutSe
 	defer f.Close()
 
 	w := bufio.NewWriter(f)
-	defer w.Flush()
+	defer func() {
+		if ferr := w.Flush(); ferr != nil && err == nil {
+			err = ferr
+		}
+	}()
 
 	fmt.Fprintf(w, "# Sweep Results: %s\n\n", modelStem)
 	fmt.Fprintf(w, "Generated: %s\n\n", time.Now().UTC().Format("2006-01-02T15:04:05Z"))
@@ -299,7 +303,7 @@ func GenerateMarkdown(outputDir, modelStem, goalSpec, goalSort string, timeoutSe
 }
 
 // GenerateCrossModelSummary writes summary.md comparing results across model subdirs.
-func GenerateCrossModelSummary(outputDir string, stems []string) error {
+func GenerateCrossModelSummary(outputDir string, stems []string) (err error) {
 	if len(stems) < 2 {
 		return nil
 	}
@@ -357,7 +361,11 @@ func GenerateCrossModelSummary(outputDir string, stems []string) error {
 	defer f.Close()
 
 	w := bufio.NewWriter(f)
-	defer w.Flush()
+	defer func() {
+		if ferr := w.Flush(); ferr != nil && err == nil {
+			err = ferr
+		}
+	}()
 
 	fmt.Fprintln(w, "# Multi-Model Sweep Summary")
 	fmt.Fprintln(w)

--- a/phase/common.go
+++ b/phase/common.go
@@ -253,8 +253,10 @@ func RecordAndTrack(ctx context.Context, env *PhaseEnv, label string, p bench.Ru
 		binaryLabel = bl
 	}
 
-	_ = output.AppendRecord(env.OutputDir, env.ModelPath, env.ModelStem,
-		jp, res, p.Phase, p.PhaseLabel, binaryLabel)
+	if err := output.AppendRecord(env.OutputDir, env.ModelPath, env.ModelStem,
+		jp, res, p.Phase, p.PhaseLabel, binaryLabel); err != nil {
+		env.Logger.Warn("AppendRecord failed: %v", err)
+	}
 
 	return res.Status, bench.TGSpeed(res.Results), bench.PPSpeed(res.Results)
 }


### PR DESCRIPTION
## Summary
- `AppendRecord` errors now logged as warnings instead of `_ =` — prevents silent data loss when disk is full
- Empty parse results with zero exit code now returns `StatusError` instead of `StatusOK` with no throughput
- `bufio.Flush()` errors in `GenerateMarkdown` and `GenerateCrossModelSummary` captured via named return values

Closes #43

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Manual: fill disk during sweep, verify warning is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)