### PR TITLE
feat: add CI pipeline with tests, vet, and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go vet ./...
+      - run: go test -race ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Test before release
+        run: go test ./...
+
       - name: Build binaries
         run: |
           VERSION="${GITHUB_REF_NAME}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.7.2] — 2026-04-09
+
+### Added
+- CI pipeline (`ci.yml`): runs `go vet` and `go test -race` on every push/PR, plus `golangci-lint` for static analysis.
+- Release workflow now runs `go test` before building binaries.
+
+---
+
 ## [1.7.1] — 2026-04-09
 
 ### Fixed


### PR DESCRIPTION
## Summary
- New `.github/workflows/ci.yml` runs `go vet`, `go test -race`, and `golangci-lint` on every push to main and all PRs
- `release.yml` now runs `go test` before building release binaries

Closes #44

## Test plan
- [x] Workflow YAML syntax validated
- [ ] Verify CI runs on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)