### PR TITLE
fix: thermal monitor dispatches shell pipelines via sh -c on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - CI pipeline (`ci.yml`): runs `go vet` and `go test -race` on every push/PR, plus `golangci-lint` for static analysis.
 - Release workflow now runs `go test` before building binaries.
 
+### Fixed
+- Thermal monitor on Linux: shell pipeline commands (containing `|`, `>`, `<`) are now dispatched via `sh -c` instead of `strings.Fields` splitting. Previously, `sensors ... | awk ...` was passed as literal arguments to `sensors`, making the thermal guard a silent no-op on Linux AMD/Intel hardware.
+- Sysfs fallback (`/sys/class/thermal/thermal_zone0/temp`) now divides by 1000 to convert millidegrees to degrees Celsius.
+
 ---
 
 ## [1.7.1] — 2026-04-09

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -938,6 +938,12 @@ function wait_cool():
         sleep SWEEP_COOL_POLL_SEC
 ```
 
+Temperature commands are stored as shell strings (e.g., `sensors | awk ...`).
+`readTemp` detects shell operators (`|`, `>`, `<`) and dispatches those via
+`sh -c`; simple single-command strings are run directly via `exec.Command`.
+The sysfs fallback (`/sys/class/thermal/thermal_zone0/temp`) uses `awk` to
+convert millidegrees to degrees.
+
 Thresholds are intentionally 2 °C below the hard limits (90 °C / 83 °C) so
 cooling begins before hitting the limit, not at it.
 

--- a/hardware/detect_linux.go
+++ b/hardware/detect_linux.go
@@ -134,7 +134,8 @@ func linuxRAM() (total, free int) {
 func linuxCPUTempCmd() string {
 	if !isCommandAvailable("sensors") {
 		if _, err := os.Stat("/sys/class/thermal/thermal_zone0/temp"); err == nil {
-			return "cat /sys/class/thermal/thermal_zone0/temp"
+			// sysfs returns millidegrees — awk converts: 45000 → 45
+			return "awk '{printf \"%d\", $1/1000}' /sys/class/thermal/thermal_zone0/temp"
 		}
 		return ""
 	}

--- a/hardware/thermal.go
+++ b/hardware/thermal.go
@@ -57,27 +57,44 @@ func (tm *ThermalMonitor) WaitCool(ctx context.Context) {
 
 // readTemp runs a temp command and returns the integer °C value.
 // Returns 0 if the command is empty or fails.
+// Commands containing shell operators (|, >, <) are dispatched via "sh -c".
 func (tm *ThermalMonitor) readTemp(cmdStr string) int {
 	if cmdStr == "" {
 		return 0
 	}
-	// For simple single-word commands like "osx-cpu-temp"
-	parts := strings.Fields(cmdStr)
-	if len(parts) == 0 {
-		return 0
+
+	var out []byte
+	var err error
+
+	// Detect shell pipeline/redirection — must run via sh -c
+	if strings.ContainsAny(cmdStr, "|><") {
+		out, err = exec.Command("sh", "-c", cmdStr).Output()
+	} else {
+		parts := strings.Fields(cmdStr)
+		if len(parts) == 0 {
+			return 0
+		}
+		out, err = exec.Command(parts[0], parts[1:]...).Output()
 	}
-	out, err := exec.Command(parts[0], parts[1:]...).Output()
 	if err != nil {
 		return 0
 	}
+
 	// Extract first integer from output
 	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return 0
+	}
 	// Some outputs have decimals; take integer part
 	if idx := strings.IndexByte(s, '.'); idx >= 0 {
 		s = s[:idx]
 	}
 	// Take first whitespace-delimited token
-	s = strings.Fields(s)[0]
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return 0
+	}
+	s = fields[0]
 	n, _ := strconv.Atoi(s)
 	return n
 }


### PR DESCRIPTION
## Summary
- `readTemp` now detects shell operators (`|`, `>`, `<`) and dispatches via `sh -c` instead of `strings.Fields` splitting
- Previously, `sensors ... | awk ...` was passed as literal arguments, making thermal guard a silent no-op on Linux AMD/Intel
- Sysfs fallback (`/sys/class/thermal/thermal_zone0/temp`) now divides millidegrees by 1000

Closes #42

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Manual: verify `sensors | awk` pipeline executes correctly on Linux AMD system

🤖 Generated with [Claude Code](https://claude.com/claude-code)