### PR TITLE
fix: guard GGUF parser against unbounded memory allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Fixed
 - Thermal monitor on Linux: shell pipeline commands (containing `|`, `>`, `<`) are now dispatched via `sh -c` instead of `strings.Fields` splitting. Previously, `sensors ... | awk ...` was passed as literal arguments to `sensors`, making the thermal guard a silent no-op on Linux AMD/Intel hardware.
 - Sysfs fallback (`/sys/class/thermal/thermal_zone0/temp`) now divides by 1000 to convert millidegrees to degrees Celsius.
+- GGUF parser: added upper-bound checks on key length (64 KiB), string length (1 MiB), and array length (1M elements) before allocating. A malformed `.gguf` file can no longer exhaust RAM via oversized `make()` calls.
 
 ---
 

--- a/gguf/parser.go
+++ b/gguf/parser.go
@@ -8,6 +8,13 @@ import (
 	"os"
 )
 
+// Safety limits to prevent OOM from malformed GGUF files.
+const (
+	maxGGUFKeyLen    = 1 << 16 // 64 KiB — longest observed GGUF key is ~100 bytes
+	maxGGUFStringLen = 1 << 20 // 1 MiB — longest string value
+	maxGGUFArrayLen  = 1 << 20 // 1 M elements
+)
+
 const (
 	ggufMagic   = 0x46554747 // "GGUF"
 	typeUINT8   = 0
@@ -192,6 +199,9 @@ func readKV(r io.Reader) (string, any, error) {
 	if err != nil {
 		return "", nil, err
 	}
+	if kLen > maxGGUFKeyLen {
+		return "", nil, fmt.Errorf("GGUF key length %d exceeds limit %d", kLen, maxGGUFKeyLen)
+	}
 	keyBytes := make([]byte, kLen)
 	if _, err := io.ReadFull(r, keyBytes); err != nil {
 		return "", nil, err
@@ -248,6 +258,9 @@ func readValue(r io.Reader, vtype uint32) (any, error) {
 		if err != nil {
 			return nil, err
 		}
+		if sLen > maxGGUFStringLen {
+			return nil, fmt.Errorf("GGUF string length %d exceeds limit %d", sLen, maxGGUFStringLen)
+		}
 		buf := make([]byte, sLen)
 		if _, err := io.ReadFull(r, buf); err != nil {
 			return nil, err
@@ -261,6 +274,9 @@ func readValue(r io.Reader, vtype uint32) (any, error) {
 		aLen, err := readU64(r)
 		if err != nil {
 			return nil, err
+		}
+		if aLen > maxGGUFArrayLen {
+			return nil, fmt.Errorf("GGUF array length %d exceeds limit %d", aLen, maxGGUFArrayLen)
 		}
 		elems := make([]any, aLen)
 		for i := uint64(0); i < aLen; i++ {


### PR DESCRIPTION
## Summary
- Added safety caps before `make()` calls in `gguf/parser.go` for key length (64 KiB), string length (1 MiB), and array length (1M elements)
- A malformed `.gguf` file can no longer exhaust RAM — returns a clean error instead

Closes #41

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes (existing GGUF parser tests still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)