### PR TITLE
fix: parseOptInt reports errors instead of silently swallowing bad input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `bufio.Writer.Flush()` errors in `GenerateMarkdown` and `GenerateCrossModelSummary` are now captured via named return values instead of silently dropped by `defer w.Flush()`.
 - Fixed unchecked `fmt.Sscanf` and `fmt.Scan` return values flagged by `errcheck` linter.
 - Simplified `jsonlParamsJSON` struct literal to direct type conversion (`gosimple S1016`).
+- `parseOptInt` now returns an error on invalid integer values (e.g., `--start-ngl abc`) instead of silently treating them as unset. The sweep fails fast with a clear error message.
 
 ### Removed
 - Dead code cleanup: removed `ParseThreadValues`, `ThreadValuesToAny`, `maxFloat`, `formatError`, `containsStr`, `binaryLabel` suppression, unused `axis` parameter from `ApplyPhase7MinsInt`, unused second parameter from `printHardwareSummary`, and `cmd.ParsePhaseList` re-export.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,17 +119,32 @@ func Parse(args []string, version string) (*config.Config, []string, error) {
 	if skipPhases != "" {
 		cfg.SkipPhases = config.ParsePhaseList(skipPhases)
 	}
-	cfg.StartNGL = parseOptInt(startNGL)
-	cfg.StartThreads = parseOptInt(startThreads)
-	cfg.StartCtx = parseOptInt(startCtx)
-	cfg.StartB = parseOptInt(startB)
-	cfg.StartUB = parseOptInt(startUB)
-	cfg.StartFA = parseOptInt(startFA)
-	cfg.MinNGL = parseOptInt(minNGL)
-	cfg.MinThreads = parseOptInt(minThreads)
-	cfg.MinCtx = parseOptInt(minCtx)
-	cfg.MinB = parseOptInt(minB)
-	cfg.MinUB = parseOptInt(minUB)
+
+	// Parse integer flags — fail fast on invalid values
+	intFlags := []struct {
+		name string
+		src  string
+		dst  **int
+	}{
+		{"--start-ngl", startNGL, &cfg.StartNGL},
+		{"--start-threads", startThreads, &cfg.StartThreads},
+		{"--start-ctx", startCtx, &cfg.StartCtx},
+		{"--start-b", startB, &cfg.StartB},
+		{"--start-ub", startUB, &cfg.StartUB},
+		{"--start-fa", startFA, &cfg.StartFA},
+		{"--min-ngl", minNGL, &cfg.MinNGL},
+		{"--min-threads", minThreads, &cfg.MinThreads},
+		{"--min-ctx", minCtx, &cfg.MinCtx},
+		{"--min-b", minB, &cfg.MinB},
+		{"--min-ub", minUB, &cfg.MinUB},
+	}
+	for _, f := range intFlags {
+		v, err := parseOptInt(f.src)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", f.name, err)
+		}
+		*f.dst = v
+	}
 
 	// Build model list from --model flag
 	var models []string
@@ -221,16 +236,16 @@ func validateModel(path string) error {
 	return nil
 }
 
-func parseOptInt(s string) *int {
+func parseOptInt(s string) (*int, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return nil
+		return nil, nil
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("invalid integer value %q: %w", s, err)
 	}
-	return &n
+	return &n, nil
 }
 
 


### PR DESCRIPTION
## Summary
- `parseOptInt` now returns `(*int, error)` instead of silently returning `nil` on parse failure
- All 11 optional integer flags (`--start-ngl`, `--min-ctx`, etc.) now fail fast with clear error messages
- Refactored callers to use a table-driven approach

Closes #49

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Manual: `./llamaseye --start-ngl abc` should print `--start-ngl: invalid integer value "abc"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)