### PR TITLE
fix: validate turbo/rotor binaries via --help probe (closes #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - Fixed unchecked `fmt.Sscanf` and `fmt.Scan` return values flagged by `errcheck` linter.
 - Simplified `jsonlParamsJSON` struct literal to direct type conversion (`gosimple S1016`).
 - `parseOptInt` now returns an error on invalid integer values (e.g., `--start-ngl abc`) instead of silently treating them as unset. The sweep fails fast with a clear error message.
+- `detectTurbo` renamed to `validateBenchBinary` — now actually runs `<binary> --help` and checks for the expected marker string (`turbo3` for TurboQuant, `planar3` for RotorQuant) instead of only checking that the file exists with the execute bit. A standard llama-bench at the wrong path will no longer be silently accepted.
+- Eliminated double `os.Stat` call (TOCTOU race) in binary validation.
 
 ### Removed
 - Dead code cleanup: removed `ParseThreadValues`, `ThreadValuesToAny`, `maxFloat`, `formatError`, `containsStr`, `binaryLabel` suppression, unused `axis` parameter from `ApplyPhase7MinsInt`, unused second parameter from `printHardwareSummary`, and `cmd.ParsePhaseList` re-export.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ results/<model-stem>/
 
 ### TurboQuant binary
 
-When `--turbo-bench <path>` is passed, runs using `turbo2`/`turbo3`/`turbo4` KV types are dispatched to that binary; all other runs use the standard binary. The turbo binary is built from the `feature/turboquant-kv-cache` branch of `github.com/TheTom/llama-cpp-turboquant`. Verified at startup by checking `--help` output contains "turbo3". Invalid path = silently disabled.
+When `--turbo-bench <path>` is passed, runs using `turbo2`/`turbo3`/`turbo4` KV types are dispatched to that binary; all other runs use the standard binary. The turbo binary is built from the `feature/turboquant-kv-cache` branch of `github.com/TheTom/llama-cpp-turboquant`. Verified at startup by running `<binary> --help` and checking the output contains "turbo3". The same mechanism validates `--rotor-bench` using "planar3" as the marker. Invalid or non-matching path = silently disabled.
 
 ### Flag/env var convention
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release --target llama-bench -j$(nproc)
 ```
 
-llamaseye verifies the binary at startup by probing it with `-ctk turbo3`. If the flag is accepted, turbo types are enabled. If the path is missing or the flag is rejected, turbo types are silently omitted and the sweep continues with the standard KV type set. It is safe to always pass `--turbo-bench` — the script handles an invalid path gracefully.
+llamaseye verifies the binary at startup by running `<binary> --help` and checking for the `turbo3` marker in the output. If the marker is present, turbo types are enabled. If the path is missing, not executable, or the marker is absent, turbo types are silently omitted and the sweep continues with the standard KV type set. It is safe to always pass `--turbo-bench` — llamaseye handles an invalid path gracefully.
 
 ### Optional: RotorQuant llama-bench
 
@@ -355,7 +355,7 @@ Passing `--turbo-bench <path>` enables three additional KV cache quantisation ty
 | `turbo3` | ~4.3× | Yes (auto-enabled) |
 | `turbo4` | ~3.2× | Yes (auto-enabled) |
 
-The TurboQuant binary is verified at startup by probing it with `-ctk turbo3`. If the flag is accepted, turbo types are enabled. If the path is missing or the flag is rejected, turbo types are silently omitted and the sweep continues with the standard KV type set. It is safe to always pass `--turbo-bench` — the script handles an invalid path gracefully.
+The TurboQuant binary is verified at startup by running `<binary> --help` and checking for the `turbo3` marker in the output. If the marker is present, turbo types are enabled. If the path is missing, not executable, or the marker is absent, turbo types are silently omitted and the sweep continues with the standard KV type set. It is safe to always pass `--turbo-bench` — llamaseye handles an invalid path gracefully.
 
 When `--turbo-bench` is available, Phase 2 also tests **asymmetric K/V combinations** (e.g. `ctk=q8_0, ctv=turbo3`) by default. TurboQuant research shows that V cache compression is effectively free — compressing V has near-zero effect on attention quality — while all quality degradation comes from K compression. Asymmetric combos capture the best of both: high K precision with aggressive V compression. Use `--no-asymmetric-kv` to restrict Phase 2 to symmetric pairs only.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1389,7 +1389,9 @@ Hardware / environment:
                              Phase 2 and Phase 7. Must be built from:
                              github.com/TheTom/llama-cpp-turboquant
                              branch: feature/turboquant-kv-cache
-                             Verified at startup — silently disabled if invalid.
+                             Verified at startup by running --help and checking
+                             for the "turbo3" marker — silently disabled if
+                             the marker is absent or the binary is invalid.
   --cpu-temp-limit <n>       °C above which sweep pauses. Default: 88.
   --gpu-temp-limit <n>       °C above which sweep pauses. Default: 81.
   --no-thermal-guard         Disable wait_cool() entirely (not recommended).

--- a/sweep/orchestrator.go
+++ b/sweep/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -57,9 +58,9 @@ func (s *Sweeper) SweepModel(ctx context.Context, modelPath string) error {
 	sel := &bench.BinarySelector{
 		StandardBin:    s.Config.LlamaBenchBin,
 		TurboBin:       s.Config.TurboBenchBin,
-		TurboAvailable: s.Config.TurboBenchBin != "" && detectTurbo(s.Config.TurboBenchBin),
+		TurboAvailable: s.Config.TurboBenchBin != "" && validateBenchBinary(s.Config.TurboBenchBin, "turbo3"),
 		RotorBin:       s.Config.RotorBenchBin,
-		RotorAvailable: s.Config.RotorBenchBin != "" && detectTurbo(s.Config.RotorBenchBin),
+		RotorAvailable: s.Config.RotorBenchBin != "" && validateBenchBinary(s.Config.RotorBenchBin, "planar3"),
 	}
 	runner := &bench.BenchRunner{
 		Config:    s.Config,
@@ -280,19 +281,21 @@ func parseGoal(spec string, hits int) *phase.GoalConfig {
 	return g
 }
 
-func detectTurbo(path string) bool {
+// validateBenchBinary checks that path is an executable file whose --help
+// output contains marker (e.g. "turbo3" for TurboQuant, "planar3" for RotorQuant).
+func validateBenchBinary(path, marker string) bool {
 	if path == "" {
 		return false
 	}
-	if _, err := os.Stat(path); err != nil {
-		return false
-	}
-	// Check executable
 	info, err := os.Stat(path)
 	if err != nil || info.Mode()&0111 == 0 {
 		return false
 	}
-	return true
+	out, err := exec.Command(path, "--help").CombinedOutput()
+	if err != nil {
+		// --help may exit non-zero on some builds; check output anyway.
+	}
+	return strings.Contains(string(out), marker)
 }
 
 func printSummary(logger *output.Logger, env *phase.PhaseEnv) {

--- a/sweep/orchestrator_test.go
+++ b/sweep/orchestrator_test.go
@@ -326,15 +326,22 @@ func TestParseGoal_PartialSpec(t *testing.T) {
 	}
 }
 
-func TestDetectTurbo_EmptyPath(t *testing.T) {
-	if detectTurbo("") {
-		t.Error("detectTurbo('') should return false")
+func TestValidateBenchBinary_EmptyPath(t *testing.T) {
+	if validateBenchBinary("", "turbo3") {
+		t.Error("validateBenchBinary('', 'turbo3') should return false")
 	}
 }
 
-func TestDetectTurbo_NonExistentPath(t *testing.T) {
-	if detectTurbo("/nonexistent/turbo-bench") {
-		t.Error("detectTurbo with nonexistent path should return false")
+func TestValidateBenchBinary_NonExistentPath(t *testing.T) {
+	if validateBenchBinary("/nonexistent/turbo-bench", "turbo3") {
+		t.Error("validateBenchBinary with nonexistent path should return false")
+	}
+}
+
+func TestValidateBenchBinary_MissingMarker(t *testing.T) {
+	// Use a real executable that won't have "turbo3" in its --help output.
+	if validateBenchBinary("/bin/echo", "turbo3") {
+		t.Error("validateBenchBinary should return false when marker is absent from --help output")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replaced `detectTurbo` (existence + exec-bit only) with `validateBenchBinary`, which runs `<binary> --help` and checks for the expected marker string (`turbo3` for TurboQuant, `planar3` for RotorQuant).
- Eliminated double `os.Stat` call (TOCTOU race).
- Added test for marker-absent case using `/bin/echo`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes — existing tests updated, new test added
- [x] Docs updated: README.md, docs/spec.md, CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)