### PR TITLE
refactor: replace []any thread working set with typed ThreadValues (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 ### Added
 - CI pipeline (`ci.yml`): runs `go vet` and `go test -race` on every push/PR, plus `golangci-lint` for static analysis.
 - Release workflow now runs `go test` before building binaries.
@@ -40,6 +41,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - `sweep.jsonl` file handle is now opened once per model sweep and reused for all records, instead of opening and closing the file for every benchmark run. Reduces syscall overhead from O(n) opens to O(1) during Phase 7's combination matrix.
+- Thread working set replaced from `[]any` (requiring type switches at every consumer) with typed `state.ThreadValues` (`[]*int`), where `nil` means "system_default". JSON format is backward-compatible — existing `state.json` files with `"system_default"` strings unmarshal correctly.
 
 ### Removed
 - Dead code cleanup: removed `ParseThreadValues`, `ThreadValuesToAny`, `maxFloat`, `formatError`, `containsStr`, `binaryLabel` suppression, unused `axis` parameter from `ApplyPhase7MinsInt`, unused second parameter from `printHardwareSummary`, and `cmd.ParsePhaseList` re-export.

--- a/phase/p3_thread_sweep.go
+++ b/phase/p3_thread_sweep.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/WagnerJust/llamaseye/bench"
+	"github.com/WagnerJust/llamaseye/state"
 )
 
 // P3ThreadSweep sweeps CPU thread counts.
@@ -45,7 +46,7 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 
 	// System default run first (no -t flag)
 	if existing, skip := ShouldSkip(env, 3, "sys"); skip {
-		env.WS.Threads = append(env.WS.Threads, "system_default")
+		env.WS.Threads = append(env.WS.Threads, nil)
 		if existing.TG > bestTG {
 			bestTG = existing.TG
 		}
@@ -65,7 +66,7 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 			PhaseLabel: "thread_sweep",
 		})
 		if status == bench.StatusOK {
-			env.WS.Threads = append(env.WS.Threads, "system_default")
+			env.WS.Threads = append(env.WS.Threads, nil)
 			if tg > bestTG {
 				bestTG = tg
 				// system default → leave env.Best.Threads nil
@@ -82,7 +83,7 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 
 		comboKey := fmt.Sprintf("%d", t)
 		if existing, skip := ShouldSkip(env, 3, comboKey); skip {
-			env.WS.Threads = append(env.WS.Threads, t)
+			tc := t; env.WS.Threads = append(env.WS.Threads, &tc)
 			if existing.TG > bestTG {
 				bestTG = existing.TG
 				tc := t
@@ -108,7 +109,7 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 			PhaseLabel: "thread_sweep",
 		})
 		if status == bench.StatusOK {
-			env.WS.Threads = append(env.WS.Threads, t)
+			tc := t; env.WS.Threads = append(env.WS.Threads, &tc)
 			if tg > bestTG {
 				bestTG = tg
 				tc2 := t
@@ -118,7 +119,7 @@ func (P3ThreadSweep) Run(ctx context.Context, env *PhaseEnv) error {
 	}
 
 	if len(env.WS.Threads) == 0 {
-		env.WS.Threads = []any{"system_default"}
+		env.WS.Threads = state.ThreadValues{nil}
 	}
 	bestThreadsStr := "system default"
 	if env.Best.Threads != nil {

--- a/phase/p7_combination_matrix.go
+++ b/phase/p7_combination_matrix.go
@@ -149,14 +149,7 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 								default:
 								}
 
-								var threads *int
-								switch t := threadVal.(type) {
-								case int:
-									tc := t
-									threads = &tc
-								}
-
-								p7Key := output.ComboKey(7, ngl, fa, ctk, ctv, nkvo, threads, bub.B, bub.UB, ctxVal)
+								p7Key := output.ComboKey(7, ngl, fa, ctk, ctv, nkvo, threadVal, bub.B, bub.UB, ctxVal)
 								if _, skip := ShouldSkip(env, 7, p7Key); skip {
 									skipCount++
 									continue
@@ -171,7 +164,7 @@ func (p P7CombinationMatrix) Run(ctx context.Context, env *PhaseEnv) error {
 									CTK:        ctk,
 									CTV:        ctv,
 									NKVO:       nkvo,
-									Threads:    threads,
+									Threads:    threadVal,
 									B:          bub.B,
 									UB:         bub.UB,
 									NPrompt:    ctxVal,
@@ -344,23 +337,14 @@ func filterBUBByMinB(bubs []state.BUBCombo, minB *int) []state.BUBCombo {
 	return result
 }
 
-func filterThreadsByMin(threads []any, minThreads *int) []any {
+func filterThreadsByMin(threads state.ThreadValues, minThreads *int) state.ThreadValues {
 	if minThreads == nil {
 		return threads
 	}
-	var result []any
+	var result state.ThreadValues
 	for _, v := range threads {
-		switch t := v.(type) {
-		case int:
-			if t >= *minThreads {
-				result = append(result, v)
-			}
-		case float64:
-			if int(t) >= *minThreads {
-				result = append(result, v)
-			}
-		case string:
-			result = append(result, v) // "system_default" always passes
+		if v == nil || *v >= *minThreads {
+			result = append(result, v)
 		}
 	}
 	return result

--- a/phase/phase.go
+++ b/phase/phase.go
@@ -37,7 +37,7 @@ type WorkingSets struct {
 	FACTK     []state.FACTKCombo
 	CTKValues []string // independent CTK axis populated by Phase 2, used by Phase 7
 	CTVValues []string // independent CTV axis populated by Phase 2, used by Phase 7
-	Threads   []any    // int or "system_default" string
+	Threads   state.ThreadValues // nil entry = system_default
 	NKVO      []int
 	BUB       []state.BUBCombo
 	CTX       []int

--- a/phase/phases_test.go
+++ b/phase/phases_test.go
@@ -230,7 +230,7 @@ func TestP7CombinationMatrix_PrecisionFilter(t *testing.T) {
 	env.WS.CTVValues = []string{"q8_0", "f16"} // f16 more precise than q8_0 — should be filtered
 	env.WS.FACTK = []state.FACTKCombo{{FA: 1, CTK: "q8_0", CTV: "q8_0"}}
 	env.WS.NKVO = []int{0}
-	env.WS.Threads = []any{"system_default"}
+	env.WS.Threads = state.ThreadValues{nil}
 	env.WS.BUB = []state.BUBCombo{{B: 2048, UB: 512}}
 	env.WS.CTX = []int{8192}
 	env.Config.MinCTK = "q8_0"
@@ -265,7 +265,7 @@ func TestP7CombinationMatrix_IndependentKV(t *testing.T) {
 		{FA: 1, CTK: "q8_0", CTV: "q8_0"},
 	}
 	env.WS.NKVO = []int{0}
-	env.WS.Threads = []any{"system_default"}
+	env.WS.Threads = state.ThreadValues{nil}
 	env.WS.BUB = []state.BUBCombo{{B: 2048, UB: 512}}
 	env.WS.CTX = []int{8192}
 	env.Config.MinCTK = "q8_0"
@@ -430,7 +430,7 @@ func TestP7CombinationMatrix_GoalEarlyExit(t *testing.T) {
 	env.WS.NGL = []int{32}
 	env.WS.FACTK = []state.FACTKCombo{{FA: 1, CTK: "f16", CTV: "f16"}}
 	env.WS.NKVO = []int{0}
-	env.WS.Threads = []any{"system_default"}
+	env.WS.Threads = state.ThreadValues{nil}
 	env.WS.BUB = []state.BUBCombo{{B: 2048, UB: 512}}
 	env.WS.CTX = []int{4096, 8192, 16384, 32768, 65536}
 
@@ -583,7 +583,7 @@ func TestP7CombinationMatrix_NoGoal(t *testing.T) {
 	env.WS.NGL = []int{32}
 	env.WS.FACTK = []state.FACTKCombo{{FA: 1, CTK: "f16", CTV: "f16"}}
 	env.WS.NKVO = []int{0}
-	env.WS.Threads = []any{"system_default"}
+	env.WS.Threads = state.ThreadValues{nil}
 	env.WS.BUB = []state.BUBCombo{{B: 2048, UB: 512}}
 	env.WS.CTX = []int{4096}
 

--- a/state/state.go
+++ b/state/state.go
@@ -3,6 +3,7 @@ package state
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -33,13 +34,52 @@ type BUBCombo struct {
 	UB int `json:"ub"`
 }
 
+// ThreadValues is a JSON-compatible list of thread counts where nil means
+// "system_default" (no -t flag). JSON representation: [4, 8, "system_default"].
+type ThreadValues []*int
+
+func (tv ThreadValues) MarshalJSON() ([]byte, error) {
+	raw := make([]any, len(tv))
+	for i, v := range tv {
+		if v == nil {
+			raw[i] = "system_default"
+		} else {
+			raw[i] = *v
+		}
+	}
+	return json.Marshal(raw)
+}
+
+func (tv *ThreadValues) UnmarshalJSON(data []byte) error {
+	var raw []any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	result := make(ThreadValues, 0, len(raw))
+	for _, v := range raw {
+		switch val := v.(type) {
+		case string:
+			if val == "system_default" {
+				result = append(result, nil)
+			}
+		case float64:
+			n := int(val)
+			result = append(result, &n)
+		default:
+			return fmt.Errorf("unexpected thread value type %T", v)
+		}
+	}
+	*tv = result
+	return nil
+}
+
 // WorkingSets holds the accumulated output of each sweep phase.
 type WorkingSets struct {
 	NGL          []int        `json:"ngl"`
 	FACTKCombos  []FACTKCombo `json:"fa_ctk_combos"`
 	CTKValues    []string     `json:"ctk_values"`    // independent CTK axis for Phase 7
 	CTVValues    []string     `json:"ctv_values"`    // independent CTV axis for Phase 7
-	ThreadValues []any        `json:"thread_values"` // int or "system_default"
+	ThreadValues ThreadValues `json:"thread_values"`
 	NKVOValues   []int        `json:"nkvo_values"`
 	BUBCombos    []BUBCombo   `json:"b_ub_combos"`
 	CTXValues    []int        `json:"ctx_values"`

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+func intPtr(n int) *int { return &n }
+
 func TestRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	threads := 8
@@ -37,7 +39,7 @@ func TestRoundTrip(t *testing.T) {
 				{B: 2048, UB: 512},
 				{B: 1024, UB: 256},
 			},
-			ThreadValues: []any{float64(4), float64(8), "system_default"},
+			ThreadValues: ThreadValues{intPtr(4), intPtr(8), nil},
 		},
 	}
 
@@ -217,6 +219,35 @@ func TestDefaultBest(t *testing.T) {
 	}
 }
 
+func TestThreadValues_JSON(t *testing.T) {
+	orig := ThreadValues{intPtr(4), nil, intPtr(8)}
+	data, err := orig.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	// Should produce [4,"system_default",8]
+	want := `[4,"system_default",8]`
+	if string(data) != want {
+		t.Errorf("MarshalJSON = %s, want %s", data, want)
+	}
+
+	var loaded ThreadValues
+	if err := loaded.UnmarshalJSON(data); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if len(loaded) != 3 {
+		t.Fatalf("len = %d, want 3", len(loaded))
+	}
+	if loaded[0] == nil || *loaded[0] != 4 {
+		t.Errorf("[0] = %v, want 4", loaded[0])
+	}
+	if loaded[1] != nil {
+		t.Errorf("[1] = %v, want nil (system_default)", loaded[1])
+	}
+	if loaded[2] == nil || *loaded[2] != 8 {
+		t.Errorf("[2] = %v, want 8", loaded[2])
+	}
+}
 
 func TestLoad_InvalidJSON(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Replaced `[]any` thread working set with `state.ThreadValues` (`[]*int`) where `nil` means "system_default"
- Eliminated all type switches (`int`, `float64`, `string`) at consumer sites in Phase 3, Phase 7, and `filterThreadsByMin`
- Added `MarshalJSON`/`UnmarshalJSON` for backward-compatible JSON (existing `state.json` files unmarshal correctly)
- Replaced `ParseThreadValues`/`ThreadValuesToAny` dead helpers with proper `TestThreadValues_JSON` test

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes — roundtrip test confirms JSON backward compatibility
- [x] No behavioral changes — same JSON format, same runtime semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)