### PR TITLE
perf: open sweep.jsonl once per model sweep (closes #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [1.7.2] — 2026-04-09
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 ### Added
 - CI pipeline (`ci.yml`): runs `go vet` and `go test -race` on every push/PR, plus `golangci-lint` for static analysis.
 - Release workflow now runs `go test` before building binaries.
@@ -36,6 +37,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `detectTurbo` renamed to `validateBenchBinary` — now actually runs `<binary> --help` and checks for the expected marker string (`turbo3` for TurboQuant, `planar3` for RotorQuant) instead of only checking that the file exists with the execute bit. A standard llama-bench at the wrong path will no longer be silently accepted.
 - Eliminated double `os.Stat` call (TOCTOU race) in binary validation.
 - `SweepModel` no longer mutates `s.Logger` — per-model logger is now a local variable, preventing shared state corruption across sequential model sweeps and eliminating a potential data race if models were ever swept concurrently.
+
+### Changed
+- `sweep.jsonl` file handle is now opened once per model sweep and reused for all records, instead of opening and closing the file for every benchmark run. Reduces syscall overhead from O(n) opens to O(1) during Phase 7's combination matrix.
 
 ### Removed
 - Dead code cleanup: removed `ParseThreadValues`, `ThreadValuesToAny`, `maxFloat`, `formatError`, `containsStr`, `binaryLabel` suppression, unused `axis` parameter from `ApplyPhase7MinsInt`, unused second parameter from `printHardwareSummary`, and `cmd.ParsePhaseList` re-export.

--- a/output/jsonl.go
+++ b/output/jsonl.go
@@ -69,8 +69,51 @@ type jsonlResult struct {
 	StddevTS float64 `json:"stddev_ts"`
 }
 
+// JSONLWriter holds an open file handle for writing sweep.jsonl records.
+// Call Close when the sweep is complete.
+type JSONLWriter struct {
+	f *os.File
+}
+
+// NewJSONLWriter opens (or creates) sweep.jsonl in outputDir for append.
+func NewJSONLWriter(outputDir string) (*JSONLWriter, error) {
+	f, err := os.OpenFile(filepath.Join(outputDir, "sweep.jsonl"),
+		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONLWriter{f: f}, nil
+}
+
+// Close flushes and closes the underlying file.
+func (w *JSONLWriter) Close() error {
+	return w.f.Close()
+}
+
+// WriteRecord constructs and writes one JSON line to the open file.
+func (w *JSONLWriter) WriteRecord(modelPath, modelStem string,
+	p JSONLParams, result *bench.RunResult,
+	phase int, phaseLabel, binaryLabel string) error {
+	return writeJSONLRecord(w.f, modelPath, modelStem, p, result, phase, phaseLabel, binaryLabel)
+}
+
 // AppendRecord constructs and appends one JSON line to outputDir/sweep.jsonl.
+// Deprecated: prefer JSONLWriter for batch writes; this opens and closes the file per call.
 func AppendRecord(outputDir, modelPath, modelStem string,
+	p JSONLParams, result *bench.RunResult,
+	phase int, phaseLabel, binaryLabel string) error {
+
+	f, err := os.OpenFile(filepath.Join(outputDir, "sweep.jsonl"),
+		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return writeJSONLRecord(f, modelPath, modelStem, p, result, phase, phaseLabel, binaryLabel)
+}
+
+// writeJSONLRecord constructs one JSON line and writes it to w.
+func writeJSONLRecord(w *os.File, modelPath, modelStem string,
 	p JSONLParams, result *bench.RunResult,
 	phase int, phaseLabel, binaryLabel string) error {
 
@@ -88,7 +131,7 @@ func AppendRecord(outputDir, modelPath, modelStem string,
 
 	// Viable
 	if result.Status == bench.StatusOK && p.NGen > 0 {
-		v := bench.TGSpeed(result.Results) >= 2.0 // will be overridden by caller if needed
+		v := bench.TGSpeed(result.Results) >= 2.0
 		rec.Viable = &v
 	}
 
@@ -107,13 +150,13 @@ func AppendRecord(outputDir, modelPath, modelStem string,
 		rec.Results = append(rec.Results, jr)
 	}
 	if rec.Results == nil {
-		rec.Results = []jsonlResult{} // always emit array, not null
+		rec.Results = []jsonlResult{}
 	}
 
 	// Wall time
 	if result.WallTimeSec > 0 {
-		w := result.WallTimeSec
-		rec.WallTimeSec = &w
+		wt := result.WallTimeSec
+		rec.WallTimeSec = &wt
 	}
 
 	// Raw output file
@@ -128,20 +171,12 @@ func AppendRecord(outputDir, modelPath, modelStem string,
 		rec.ErrorSnippet = &e
 	}
 
-	// Append to sweep.jsonl
 	line, err := json.Marshal(rec)
 	if err != nil {
 		return err
 	}
 	line = append(line, '\n')
-
-	f, err := os.OpenFile(filepath.Join(outputDir, "sweep.jsonl"),
-		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	_, err = f.Write(line)
+	_, err = w.Write(line)
 	return err
 }
 

--- a/phase/common.go
+++ b/phase/common.go
@@ -246,9 +246,16 @@ func RecordAndTrack(ctx context.Context, env *PhaseEnv, label string, p bench.Ru
 		binaryLabel = bl
 	}
 
-	if err := output.AppendRecord(env.OutputDir, env.ModelPath, env.ModelStem,
-		jp, res, p.Phase, p.PhaseLabel, binaryLabel); err != nil {
-		env.Logger.Warn("AppendRecord failed: %v", err)
+	if env.JSONLWriter != nil {
+		if err := env.JSONLWriter.WriteRecord(env.ModelPath, env.ModelStem,
+			jp, res, p.Phase, p.PhaseLabel, binaryLabel); err != nil {
+			env.Logger.Warn("WriteRecord failed: %v", err)
+		}
+	} else {
+		if err := output.AppendRecord(env.OutputDir, env.ModelPath, env.ModelStem,
+			jp, res, p.Phase, p.PhaseLabel, binaryLabel); err != nil {
+			env.Logger.Warn("AppendRecord failed: %v", err)
+		}
 	}
 
 	return res.Status, bench.TGSpeed(res.Results), bench.PPSpeed(res.Results)

--- a/phase/phase.go
+++ b/phase/phase.go
@@ -45,18 +45,19 @@ type WorkingSets struct {
 
 // PhaseEnv is the shared mutable state passed to every phase.
 type PhaseEnv struct {
-	Config     *config.Config
-	HW         *hardware.HardwareInfo
-	Runner     *bench.BenchRunner
-	Thermal    *hardware.ThermalMonitor
-	Logger     *output.Logger
-	MaxNGL     int
-	NumLayers  int // model layer count from GGUF metadata; 0 = unknown
-	Best       BestConfig
-	WS         WorkingSets
-	OutputDir  string
-	ModelPath  string
-	ModelStem  string
+	Config      *config.Config
+	HW          *hardware.HardwareInfo
+	Runner      *bench.BenchRunner
+	Thermal     *hardware.ThermalMonitor
+	Logger      *output.Logger
+	JSONLWriter *output.JSONLWriter // opened once per SweepModel, closed by caller
+	MaxNGL      int
+	NumLayers   int // model layer count from GGUF metadata; 0 = unknown
+	Best        BestConfig
+	WS          WorkingSets
+	OutputDir   string
+	ModelPath   string
+	ModelStem   string
 
 	// SkipCombos holds combo keys from sweep.jsonl when --focused is active.
 	// Keyed by phase ID → combo key string → performance data.

--- a/sweep/orchestrator.go
+++ b/sweep/orchestrator.go
@@ -83,9 +83,17 @@ func (s *Sweeper) SweepModel(ctx context.Context, modelPath string) error {
 		DebugLog:    logger.Debugf,
 	}
 
+	// Open JSONL writer once for the entire model sweep
+	jw, err := output.NewJSONLWriter(outputDir)
+	if err != nil {
+		return fmt.Errorf("open sweep.jsonl: %w", err)
+	}
+	defer jw.Close()
+
 	// Build PhaseEnv
 	env := phase.NewPhaseEnv(s.Config, s.HW, runner, thermal, logger,
 		outputDir, modelPath, modelStem)
+	env.JSONLWriter = jw
 
 	// Parse GGUF metadata to cap NGL at the model's actual layer count.
 	// Values above NumLayers are functionally identical (llama.cpp clamps silently).


### PR DESCRIPTION
## Summary
- Added `JSONLWriter` type that holds an open file handle for the entire model sweep
- Reduces O(n) open/close syscalls to O(1) during Phase 7's combination matrix
- Falls back to `AppendRecord` (open-per-call) if no writer is set, for backward compatibility

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes — existing JSONL tests still use AppendRecord
- [x] No behavioral changes — same JSON output, same append semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)