### PR TITLE
chore: add community files, Makefile, fix stale docs (closes #51)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a bug in llamaseye
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps or command to reproduce:
+```bash
+./llamaseye --model ... --flags ...
+```
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened. Include relevant log output if available.
+
+**Environment**
+- llamaseye version: (`./llamaseye --version`)
+- OS:
+- GPU:
+- Backend (cuda/metal/cpu):
+- llama-bench version/commit:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Use case**
+What problem does this solve? What workflow does it enable?
+
+**Proposed solution**
+How should it work? Include example commands or flag names if applicable.
+
+**Alternatives considered**
+Any other approaches you've thought about.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+<!-- Brief description of the change -->
+
+## Checklist
+- [ ] `go build ./...` passes
+- [ ] `go test ./...` passes
+- [ ] `CHANGELOG.md` updated with semver bump
+- [ ] `README.md` updated (if behavior changed)
+- [ ] `docs/spec.md` updated (if behavior changed)
+- [ ] `.claude/skills/llamaseye/SKILL.md` updated (if behavior changed)
+
+## Test plan
+<!-- How was this tested? -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 - CI pipeline (`ci.yml`): runs `go vet` and `go test -race` on every push/PR, plus `golangci-lint` for static analysis.
 - Release workflow now runs `go test` before building binaries.
+- `CONTRIBUTING.md` with development setup, PR requirements, and code style guidance.
+- `.github/ISSUE_TEMPLATE/` with bug report and feature request templates.
+- `.github/pull_request_template.md` with doc-update checklist.
+- `Makefile` with `build`, `test`, `vet`, `lint`, and `clean` targets.
 
 ### Fixed
 - Thermal monitor on Linux: shell pipeline commands (containing `|`, `>`, `<`) are now dispatched via `sh -c` instead of `strings.Fields` splitting. Previously, `sensors ... | awk ...` was passed as literal arguments to `sensors`, making the thermal guard a silent no-op on Linux AMD/Intel hardware.
 - Sysfs fallback (`/sys/class/thermal/thermal_zone0/temp`) now divides by 1000 to convert millidegrees to degrees Celsius.
 - GGUF parser: added upper-bound checks on key length (64 KiB), string length (1 MiB), and array length (1M elements) before allocating. A malformed `.gguf` file can no longer exhaust RAM via oversized `make()` calls.
+- README.md: corrected stale `bash llamaseye.sh --report` reference to `./llamaseye --report`.
+- `go.mod`: removed incorrect `// indirect` comment on `pflag` (direct dependency).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to llamaseye
+
+Thank you for your interest in contributing! This guide covers everything you need to get started.
+
+## Development setup
+
+```bash
+git clone https://github.com/WagnerJust/llamaseye
+cd llamaseye
+go build -o llamaseye .
+go test ./...
+```
+
+Requires Go 1.22+.
+
+## Making changes
+
+1. **Open an issue first** — describe the bug or feature you want to work on.
+2. **Create a branch** from `main`: `git checkout -b feat/my-feature` or `fix/my-bug`.
+3. **Write code** — follow existing patterns and conventions in the codebase.
+4. **Run tests**: `go test ./...`
+5. **Run vet**: `go vet ./...`
+6. **Open a PR** against `main`.
+
+## PR requirements
+
+Every PR that changes behavior must update:
+
+- [ ] `CHANGELOG.md` — add an entry with a semver bump ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format)
+- [ ] `README.md` — if user-facing behavior changed
+- [ ] `docs/spec.md` — if phase behavior, JSONL schema, or output format changed
+- [ ] `.claude/skills/llamaseye/SKILL.md` — if flags, phases, or usage patterns changed
+
+Version bumps follow [Semantic Versioning](https://semver.org/):
+- **Patch** (`x.y.Z`) — bug fixes, cleanup, docs
+- **Minor** (`x.Y.0`) — new features, new flags
+- **Major** (`X.0.0`) — breaking changes to CLI, output format, or JSONL schema
+
+## Code style
+
+- Follow standard Go conventions (`gofmt`, `go vet`).
+- Keep functions focused — one function, one job.
+- Use typed representations over `interface{}` / `any` where possible.
+- Don't add features beyond what the PR addresses.
+
+## Reporting bugs
+
+Open an issue with:
+- What you expected to happen
+- What actually happened
+- Steps to reproduce
+- llamaseye version (`./llamaseye --version`)
+- Hardware info (OS, GPU, backend)
+
+## Feature requests
+
+Open an issue describing the use case and proposed solution. For large changes, discuss the approach before writing code.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: build test vet lint clean
+
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
+build:
+	go build -ldflags "-X main.version=$(VERSION)" -o llamaseye .
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
+
+lint: vet
+	@command -v golangci-lint >/dev/null 2>&1 && golangci-lint run || echo "golangci-lint not installed — skipping"
+
+clean:
+	rm -f llamaseye

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ results/
 
 `sweep.md` can be regenerated at any time from `sweep.jsonl` without re-running benchmarks:
 ```bash
-bash llamaseye.sh --report --output-dir ./results
+./llamaseye --report --output-dir ./results
 ```
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/WagnerJust/llamaseye
 
 go 1.22
 
-require github.com/spf13/pflag v1.0.5 // indirect
+require github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
## Summary
- Added `CONTRIBUTING.md` with development setup and PR requirements
- Added `.github/ISSUE_TEMPLATE/` (bug report + feature request)
- Added `.github/pull_request_template.md` with doc-update checklist
- Added `Makefile` with `build`, `test`, `vet`, `lint`, `clean` targets
- Fixed stale `bash llamaseye.sh --report` reference in README.md
- Fixed `go.mod`: removed incorrect `// indirect` on pflag

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make build && make test` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)