### PR TITLE
fix: minor code hygiene — errors.Is, dedup goal parsing, named interface (closes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [1.7.2] — 2026-04-09
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 ### Added
 - CI pipeline (`ci.yml`): runs `go vet` and `go test -race` on every push/PR, plus `golangci-lint` for static analysis.
 - Release workflow now runs `go test` before building binaries.
@@ -39,6 +35,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `detectTurbo` renamed to `validateBenchBinary` — now actually runs `<binary> --help` and checks for the expected marker string (`turbo3` for TurboQuant, `planar3` for RotorQuant) instead of only checking that the file exists with the execute bit. A standard llama-bench at the wrong path will no longer be silently accepted.
 - Eliminated double `os.Stat` call (TOCTOU race) in binary validation.
 - `SweepModel` no longer mutates `s.Logger` — per-model logger is now a local variable, preventing shared state corruption across sequential model sweeps and eliminating a potential data race if models were ever swept concurrently.
+- `state.Load` now uses `errors.Is(err, os.ErrNotExist)` instead of deprecated `os.IsNotExist`.
+- Goal spec parsing deduplicated — `config.ParseGoalSpec` is the single source of truth, replacing duplicate logic in `sweep/orchestrator.go` and `output/markdown.go`.
+- Inline anonymous `Logger` interface in `bench/runner.go` replaced with named `DebugLogger` interface for discoverability.
 
 ### Changed
 - `sweep.jsonl` file handle is now opened once per model sweep and reused for all records, instead of opening and closing the file for every benchmark run. Reduces syscall overhead from O(n) opens to O(1) during Phase 7's combination matrix.

--- a/bench/runner.go
+++ b/bench/runner.go
@@ -22,6 +22,11 @@ type CommandExecutor interface {
 	Run(ctx context.Context, binary string, args []string, stdout, stderr io.Writer) (exitCode int, err error)
 }
 
+// DebugLogger is satisfied by any logger that supports formatted debug output.
+type DebugLogger interface {
+	Debugf(string, ...any)
+}
+
 // RunParams holds all parameters for a single bench run.
 type RunParams struct {
 	NGL     int
@@ -47,7 +52,7 @@ type BenchRunner struct {
 	OutputDir string // per-model output directory (must have "raw/" subdir)
 	ModelPath string
 	ModelStem string
-	Logger    interface{ Debugf(string, ...any) } // optional; nil = no debug output
+	Logger    DebugLogger // optional; nil = no debug output
 }
 
 // llamaBenchLine is a single JSON record emitted by llama-bench -o jsonl.

--- a/config/config.go
+++ b/config/config.go
@@ -286,3 +286,31 @@ func (c *Config) Validate() error {
 	}
 	return nil
 }
+
+// GoalSpec holds the parsed fields from a goal spec string like "ctx=32768,tg=5".
+type GoalSpec struct {
+	CtxMin int
+	TGMin  float64
+	PPMin  float64
+}
+
+// ParseGoalSpec parses a goal specification string (e.g. "ctx=32768,tg=5,pp=100").
+func ParseGoalSpec(spec string) GoalSpec {
+	var g GoalSpec
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "ctx":
+			fmt.Sscanf(kv[1], "%d", &g.CtxMin)
+		case "tg":
+			fmt.Sscanf(kv[1], "%f", &g.TGMin)
+		case "pp":
+			fmt.Sscanf(kv[1], "%f", &g.PPMin)
+		}
+	}
+	return g
+}

--- a/output/markdown.go
+++ b/output/markdown.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/WagnerJust/llamaseye/config"
 )
 
 // record is an internal struct for reading sweep.jsonl rows.
@@ -153,7 +155,8 @@ func GenerateMarkdown(outputDir, modelStem, goalSpec, goalSort string, timeoutSe
 
 	// Goal results section (when --goal was active and phase 7 ran)
 	if goalSpec != "" {
-		goalCtx, goalTG, goalPP := parseGoalSpec(goalSpec)
+		gs := config.ParseGoalSpec(goalSpec)
+		goalCtx, goalTG, goalPP := gs.CtxMin, gs.TGMin, gs.PPMin
 		phase7OK := filterByPhaseStatus(records, 7, "ok")
 		if len(phase7OK) > 0 {
 			fmt.Fprintf(w, "## Goal Results — %s\n\n", goalSpecDesc(goalCtx, goalTG, goalPP))
@@ -421,24 +424,6 @@ func fmtTS(v float64) string {
 	return fmt.Sprintf("%.2f", v)
 }
 
-func parseGoalSpec(spec string) (ctx int, tg, pp float64) {
-	for _, part := range strings.Split(spec, ",") {
-		part = strings.TrimSpace(part)
-		kv := strings.SplitN(part, "=", 2)
-		if len(kv) != 2 {
-			continue
-		}
-		switch kv[0] {
-		case "ctx":
-			_, _ = fmt.Sscanf(kv[1], "%d", &ctx)
-		case "tg":
-			_, _ = fmt.Sscanf(kv[1], "%f", &tg)
-		case "pp":
-			_, _ = fmt.Sscanf(kv[1], "%f", &pp)
-		}
-	}
-	return
-}
 
 func goalSpecDesc(ctx int, tg, pp float64) string {
 	var parts []string

--- a/state/state.go
+++ b/state/state.go
@@ -3,6 +3,7 @@ package state
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,7 +115,7 @@ func DefaultBest() Best {
 func Load(outputDir string) (*State, error) {
 	path := filepath.Join(outputDir, "state.json")
 	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {

--- a/sweep/orchestrator.go
+++ b/sweep/orchestrator.go
@@ -270,23 +270,13 @@ func parseGoal(spec string, hits int) *phase.GoalConfig {
 	if hits <= 0 {
 		hits = 3
 	}
-	g := &phase.GoalConfig{MaxHits: hits}
-	for _, part := range strings.Split(spec, ",") {
-		part = strings.TrimSpace(part)
-		kv := strings.SplitN(part, "=", 2)
-		if len(kv) != 2 {
-			continue
-		}
-		switch kv[0] {
-		case "ctx":
-			_, _ = fmt.Sscanf(kv[1], "%d", &g.CtxMin)
-		case "tg":
-			_, _ = fmt.Sscanf(kv[1], "%f", &g.TGMin)
-		case "pp":
-			_, _ = fmt.Sscanf(kv[1], "%f", &g.PPMin)
-		}
+	gs := config.ParseGoalSpec(spec)
+	return &phase.GoalConfig{
+		CtxMin:  gs.CtxMin,
+		TGMin:   gs.TGMin,
+		PPMin:   gs.PPMin,
+		MaxHits: hits,
 	}
-	return g
 }
 
 // validateBenchBinary checks that path is an executable file whose --help


### PR DESCRIPTION
## Summary
- Replaced `os.IsNotExist(err)` with `errors.Is(err, os.ErrNotExist)` in `state.Load`
- Extracted `config.ParseGoalSpec` to deduplicate identical goal-spec parsing in `sweep/orchestrator.go` and `output/markdown.go`
- Replaced inline anonymous `Logger interface{ Debugf(string, ...any) }` with named `DebugLogger` interface in `bench/runner.go`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] No behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)