### PR TITLE
feat: AMD GPU detection on Linux via rocm-smi (v1.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.8.1] — 2026-04-29
+
+### Added
+- AMD GPU detection on Linux via `rocm-smi`: populates GPU model, VRAM total/free, and GPU temperature monitoring. `hardware.json` now records `backend = "rocm"` for AMD systems. Requires ROCm userspace tools (`rocm-smi`) to be installed; falls back to `cpu` if absent.
+
+---
+
 ## [1.8.0] — 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The Go binary uses native OS APIs for hardware detection and thermal monitoring.
 | Tool | Purpose | Install |
 |------|---------|---------|
 | `nvidia-smi` | NVIDIA GPU VRAM/temp detection | Included with NVIDIA drivers |
+| `rocm-smi` | AMD GPU VRAM detection (Linux/ROCm) | Included with ROCm drivers |
 | `sensors` | Linux CPU temperature reading | `apt install lm-sensors` |
 | `osx-cpu-temp` | macOS CPU temperature reading (optional) | `brew install osx-cpu-temp` |
 
@@ -447,8 +448,8 @@ At startup the script probes:
 
 - **CPU cores** — via `nproc` (Linux) or `sysctl -n hw.logicalcpu` (macOS)
 - **System RAM** — to compute safe context-size upper bounds
-- **GPU VRAM** — via `nvidia-smi` or `system_profiler` (Apple Silicon)
-- **Compute backend** — cuda / metal / cpu, inferred from the llama-bench binary
+- **GPU VRAM** — via `nvidia-smi` (NVIDIA), `rocm-smi` (AMD/ROCm, Linux), or `system_profiler` (Apple Silicon)
+- **Compute backend** — cuda / metal / rocm / cpu; AMD GPUs on Linux are detected via `rocm-smi` and reported as `backend: "rocm"` in `hardware.json`
 - **Thermal sensors** — `nvidia-smi` for GPU, `sensors` or `/sys/class/thermal` for CPU
 
 All sweep parameters are derived from these detected values. The script contains no hardcoded machine-specific constants.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -78,7 +78,7 @@ HW_GPU_VRAM_GIB     Total VRAM in GiB (first GPU)
 HW_GPU_VRAM_FREE_GIB  Free VRAM at sweep start in GiB (first GPU)
 HW_GPU_TEMP_LIMIT   GPU thermal pause threshold (default: 81 °C — overridable)
 HW_CPU_TEMP_LIMIT   CPU thermal pause threshold (default: 88 °C — overridable)
-HW_BACKEND          Detected compute backend: "cuda", "metal", "cpu"
+HW_BACKEND          Detected compute backend: "cuda", "metal", "rocm", "cpu"
 ```
 
 ### How each value is read

--- a/hardware/detect.go
+++ b/hardware/detect.go
@@ -8,6 +8,7 @@ const (
 	BackendCUDA   Backend = "cuda"
 	BackendMetal  Backend = "metal"
 	BackendCPU    Backend = "cpu"
+	BackendROCm   Backend = "rocm"
 )
 
 // HardwareInfo holds the detected hardware inventory.

--- a/hardware/detect_linux.go
+++ b/hardware/detect_linux.go
@@ -22,8 +22,8 @@ func Detect() (*HardwareInfo, error) {
 	// RAM
 	h.RAMGiB, h.RAMFreeGiB = linuxRAM()
 
-	// GPU
-	if !detectNvidiaSMI(h) {
+	// GPU — NVIDIA first, then AMD, then CPU fallback.
+	if !detectNvidiaSMI(h) && !detectROCmSMI(h) {
 		h.Backend = BackendCPU
 		h.GPUCount = 0
 		h.GPUModel = "none"
@@ -33,6 +33,9 @@ func Detect() (*HardwareInfo, error) {
 	h.CPUTempCmd = linuxCPUTempCmd()
 	if h.Backend == BackendCUDA {
 		h.GPUTempCmd = "nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader -i 0"
+	}
+	if h.Backend == BackendROCm {
+		h.GPUTempCmd = "rocm-smi --showtemp 2>/dev/null | awk '/[Jj]unction.*\\(C\\):/{gsub(/[^0-9.]/,\"\",$NF); printf \"%d\", $NF}'"
 	}
 
 	return h, nil

--- a/hardware/detect_test.go
+++ b/hardware/detect_test.go
@@ -1,7 +1,6 @@
 package hardware
 
 import (
-	"runtime"
 	"testing"
 )
 
@@ -22,8 +21,14 @@ func TestDetect_Smoke(t *testing.T) {
 	if hw.CPUModel == "" {
 		t.Error("CPUModel is empty")
 	}
-	// Backend should be set on macOS (metal) or linux (cuda/cpu)
-	if runtime.GOOS == "darwin" && hw.Backend != "metal" {
-		t.Errorf("Backend = %q on darwin, want metal", hw.Backend)
+	// Backend must be a known value on every platform.
+	validBackends := map[Backend]bool{
+		BackendMetal: true,
+		BackendCUDA:  true,
+		BackendROCm:  true,
+		BackendCPU:   true,
+	}
+	if !validBackends[hw.Backend] {
+		t.Errorf("Backend = %q, want one of metal/cuda/rocm/cpu", hw.Backend)
 	}
 }

--- a/hardware/shared.go
+++ b/hardware/shared.go
@@ -53,3 +53,66 @@ func isCommandAvailable(name string) bool {
 	_, err := exec.LookPath(name)
 	return err == nil
 }
+
+// detectROCmSMI attempts to query rocm-smi and fill AMD GPU fields.
+// Returns true if an AMD GPU was found.
+func detectROCmSMI(h *HardwareInfo) bool {
+	if _, err := exec.LookPath("rocm-smi"); err != nil {
+		return false
+	}
+	if err := exec.Command("rocm-smi").Run(); err != nil {
+		return false
+	}
+
+	h.Backend = BackendROCm
+
+	if out, err := exec.Command("rocm-smi", "--showgpucount").Output(); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "GPU count:") {
+				parts := strings.SplitN(line, ":", 2)
+				if len(parts) == 2 {
+					n, _ := strconv.Atoi(strings.TrimSpace(parts[1]))
+					h.GPUCount = n
+				}
+				break
+			}
+		}
+	}
+
+	if out, err := exec.Command("rocm-smi", "--showproductname").Output(); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.Contains(line, "Card series:") {
+				parts := strings.SplitN(line, "Card series:", 2)
+				if len(parts) == 2 {
+					h.GPUModel = strings.TrimSpace(parts[1])
+				}
+				break
+			}
+		}
+	}
+
+	if out, err := exec.Command("rocm-smi", "--showmeminfo", "vram").Output(); err == nil {
+		var totalBytes, usedBytes int64
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, "VRAM Total Memory (B):") {
+				parts := strings.SplitN(line, "VRAM Total Memory (B):", 2)
+				if len(parts) == 2 {
+					totalBytes, _ = strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+				}
+			}
+			if strings.Contains(line, "VRAM Total Used Memory (B):") {
+				parts := strings.SplitN(line, "VRAM Total Used Memory (B):", 2)
+				if len(parts) == 2 {
+					usedBytes, _ = strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+				}
+			}
+		}
+		h.GPUVRAMGiB = int(totalBytes / (1 << 30))
+		if totalBytes > 0 {
+			h.GPUVRAMFreeGiB = int((totalBytes - usedBytes) / (1 << 30))
+		}
+	}
+
+	return true
+}

--- a/hardware/shared.go
+++ b/hardware/shared.go
@@ -65,6 +65,7 @@ func detectROCmSMI(h *HardwareInfo) bool {
 	}
 
 	h.Backend = BackendROCm
+	h.GPUCount = 1 // safe default; overridden below if --showgpucount parses successfully
 
 	if out, err := exec.Command("rocm-smi", "--showgpucount").Output(); err == nil {
 		for _, line := range strings.Split(string(out), "\n") {
@@ -81,7 +82,7 @@ func detectROCmSMI(h *HardwareInfo) bool {
 
 	if out, err := exec.Command("rocm-smi", "--showproductname").Output(); err == nil {
 		for _, line := range strings.Split(string(out), "\n") {
-			if strings.Contains(line, "Card series:") {
+			if strings.HasPrefix(strings.TrimSpace(line), "GPU[") && strings.Contains(line, "Card series:") {
 				parts := strings.SplitN(line, "Card series:", 2)
 				if len(parts) == 2 {
 					h.GPUModel = strings.TrimSpace(parts[1])


### PR DESCRIPTION
## Summary
- Adds `BackendROCm` (`"rocm"`) as a new hardware backend for Linux AMD GPU detection
- Probes `rocm-smi` for GPU model, VRAM total/free, and GPU temperature monitoring — mirrors the existing NVIDIA/`nvidia-smi` detection pattern exactly
- Falls back to `"cpu"` if `rocm-smi` is absent or fails; no behavior change on NVIDIA or macOS systems

## Test Plan
- [ ] All existing tests pass: `go test ./...`
- [ ] On a Linux machine with ROCm installed: `./llamaseye --model <model.gguf>` should show `backend = "rocm"` and non-zero VRAM in `hardware.json`
- [ ] On a machine without `rocm-smi`: `hardware.json` should still show `backend = "cpu"` as before